### PR TITLE
Mark games as ABANDONED when player creates new game

### DIFF
--- a/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
+++ b/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
@@ -398,6 +398,14 @@ public class NakamaMatchService {
     public void clearPlayerMatches(String playerId) {
         logger.info("Clearing matches for player: {}", playerId);
         
+        // First, find and mark all active games as ABANDONED
+        GameModel activeGame = findActiveGameForPlayer(playerId);
+        if (activeGame != null) {
+            logger.info("Marking game {} as ABANDONED for player {}", activeGame.getId(), playerId);
+            activeGame.setGameState(GameState.ABANDONED);
+            gameRepository.save(activeGame);
+        }
+        
         // Only remove matches that are at least 5 seconds old to prevent race conditions
         Instant cutoffTime = Instant.now().minusSeconds(5);
         


### PR DESCRIPTION
## Summary
- Added logic to properly mark games as ABANDONED when player abandons them for a new game

## Changes
- Updated `clearPlayerMatches` method to find active games and mark them as ABANDONED
- Games are now properly marked with ABANDONED state instead of staying IN_PROGRESS

## Test plan
- [ ] Start a game with two players
- [ ] One player creates a new game while having an active game
- [ ] Check database - old game should have state ABANDONED
- [ ] Other player should still be able to see the game state