### PR TITLE
Fix the signup email flow, and the bugs that could lose data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Live at **handoffate.org**. Do not assume anything below is still true — check
 | Auth | Supabase project `Hand-of-Fate` issues the JWT; Nakama issues game sessions |
 | Secrets | SSM Parameter Store under `/hand-of-fate/`, read at task start |
 | Cost | ~$6/month until the t4g free trial ends 2026-12-31, ~$19 after |
+| Backups | Nightly `mongodump` to S3, run as a scheduled ECS task. Atlas M0 has none of its own |
+| Email | Supabase sends through Resend, from `noreply@mail.handoffate.org` |
 
 Shell access is SSM Session Manager, not SSH — there is no open port 22.
 `infra/ecs/README.md` explains why the architecture looks the way it does; the
@@ -69,7 +71,17 @@ If it is ever recovered it becomes an alias, not a replacement.
 
 ## Known problems
 
-These are real and confirmed, not speculation. None are fixed.
+These are real and confirmed, not speculation.
+
+**No rate limiting anywhere.** Not on login, not on anything. Supabase throttles its
+own endpoints; this service does not.
+
+**Nakama passwords are derivable.** `UnifiedAuthController` derives each player's
+Nakama password from their player id and a constant that is in this repository, and
+any signed-in user can get somebody else's player id from `/players/by-name/{name}`.
+Not currently reachable — the security group has no inbound rules and Nakama's port
+is not published — but exposing Nakama for any reason turns it into account
+takeover.
 
 **Game state lives on the Player document.** Hand, placed cards, and the active
 deck are fields on `Player`, not on the game. A player can therefore only be in
@@ -84,6 +96,11 @@ instance. `getMatchState` scans the entire games collection on every call.
 
 **No concurrency control.** No `@Version` on documents, no transactions.
 Simultaneous writes overwrite each other.
+
+**A dangling DNS record.** `monitoring.handoffate.org` points at `134.199.238.66`,
+a DigitalOcean address that looks like the retired Prometheus droplet in
+`infra/monitoring`. If that machine is gone, anyone who lands on the address owns
+the subdomain.
 
 **Most tests still need infrastructure.** The suite runs in CI now, and the
 security tests are plain unit tests, but everything else is still
@@ -141,7 +158,8 @@ a checklist:
    test, fix what it finds, decide whether one `t4g.small` is still the right
    size.
 6. **Frontend.** Break up the 900-line components, fix reconnection, delete the
-   dead services, replace the fake stats on the home page.
+   dead services. (The home page's Power Score is real data, not a placeholder —
+   that item was stale.)
 
 Ordering is deliberate: 3 and 4 rewrite the core, so 2 comes first.
 

--- a/backend/src/main/java/com/cardgame/service/nakama/NakamaLeaderBoardService.java
+++ b/backend/src/main/java/com/cardgame/service/nakama/NakamaLeaderBoardService.java
@@ -5,19 +5,16 @@ import com.cardgame.dto.nakama.ImmutableLeaderboardResponseDto;
 import com.cardgame.dto.nakama.LeaderboardRecordDto;
 import com.cardgame.dto.nakama.LeaderboardResponseDto;
 import com.heroiclabs.nakama.Client;
-import com.heroiclabs.nakama.DefaultClient;
 import com.heroiclabs.nakama.Session;
 import com.heroiclabs.nakama.api.LeaderboardRecord;
 import com.heroiclabs.nakama.api.LeaderboardRecordList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -29,38 +26,31 @@ public class NakamaLeaderBoardService {
     private static final String WEEKLY_LEADERBOARD = "weekly_score";
     private static final String ALLTIME_LEADERBOARD = "all_time_score";
 
-    @Value("${nakama.host:localhost}")
-    private String host;
+    /**
+     * Identifies this service's own Nakama account.
+     *
+     * <p>It used to be a fresh UUID on every boot, which meant a new Nakama account for
+     * every restart and redeploy. One stable id reuses the same one.
+     */
+    private static final String SERVICE_DEVICE_ID = "hand-of-fate-leaderboard-service";
 
-    @Value("${nakama.port:7349}")
-    private int port;
+    private final Client client;
 
-    @Value("${nakama.serverKey:defaultkey}")
-    private String serverKey;
-
-    @Value("${nakama.ssl:false}")
-    private boolean ssl;
-
-    private Client client;
     private Session adminSession;
     private boolean initialized = false;
+
+    public NakamaLeaderBoardService(Client client) {
+        this.client = client;
+    }
 
     @PostConstruct
     public void init() {
         try {
-            // Initialize the Nakama client
-            logger.info("Initializing Nakama client with host: {}, port: {}, ssl: {}", host, port, ssl);
-            this.client = new DefaultClient(serverKey, host, port, ssl);
-
-            // Create an admin session with a unique device ID
-            String uniqueDeviceId = UUID.randomUUID().toString();
-            logger.info("Authenticating with device ID: {}", uniqueDeviceId);
-            this.adminSession = client.authenticateDevice(uniqueDeviceId).get();
+            this.adminSession = client.authenticateDevice(SERVICE_DEVICE_ID).get();
             this.initialized = true;
-
-            logger.info("Nakama client initialized successfully with device ID: {}", uniqueDeviceId);
+            logger.info("Leaderboard service authenticated with Nakama");
         } catch (Exception e) {
-            logger.error("Failed to initialize Nakama client: {}", e.getMessage(), e);
+            logger.error("Failed to authenticate the leaderboard service with Nakama: {}", e.getMessage(), e);
             this.initialized = false;
         }
     }
@@ -78,8 +68,7 @@ public class NakamaLeaderBoardService {
         } else if (adminSession == null) {
             try {
                 logger.info("Re-initializing Nakama session");
-                String uniqueDeviceId = UUID.randomUUID().toString();
-                this.adminSession = client.authenticateDevice(uniqueDeviceId).get();
+                this.adminSession = client.authenticateDevice(SERVICE_DEVICE_ID).get();
             } catch (Exception e) {
                 logger.error("Failed to re-initialize Nakama session", e);
                 this.initialized = false;

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -97,7 +97,13 @@ function UnifiedAuthPageContent() {
     try {
       const result = await unifiedAuthService.signUp(email, password, username);
       
-      if (!result.success) {
+      if (result.alreadyRegistered) {
+        // Not a failure worth a red banner — they have an account, they are just on the
+        // wrong form. Send them to the other one with the address kept.
+        setIsSignUp(false);
+        setPassword('');
+        setMessage(result.error || 'That email already has an account. Sign in below.');
+      } else if (!result.success) {
         setError(result.error || 'Sign up failed');
       } else if (result.needsEmailVerification) {
         setPendingVerification(true);

--- a/frontend/src/hooks/useUnifiedAuth.tsx
+++ b/frontend/src/hooks/useUnifiedAuth.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { unifiedAuthService, UnifiedAuthResponse } from '@/services/unifiedAuthService';
+import { SESSION_EXPIRED_EVENT, resetSessionExpiry } from '@/lib/apiClient';
 import { useRouter } from 'next/navigation';
 import { User } from '@supabase/supabase-js';
 
@@ -98,8 +99,21 @@ export function UnifiedAuthProvider({ children }: { children: ReactNode }) {
         return () => subscription.unsubscribe();
     }, []);
 
+    // The backend refused the session and refreshing it did not help. Sign out properly
+    // rather than leaving the app to answer every action with a fetch error.
+    useEffect(() => {
+        const onExpired = () => {
+            console.warn('Session expired, signing out');
+            logout();
+        };
+        window.addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+        return () => window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    }, []);
+
     const login = (authData: UnifiedAuthResponse) => {
         if (authData.isSuccess && authData.playerId) {
+            // A fresh session should be able to announce its own expiry later.
+            resetSessionExpiry();
             unifiedAuthService.storeAuthData(authData);
             setIsAuthenticated(true);
             setUser({

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -16,20 +16,6 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
  * a refresh is actually due.
  */
 
-export class UnauthorizedError extends Error {
-  constructor(message = 'Your session has expired. Please sign in again.') {
-    super(message)
-    this.name = 'UnauthorizedError'
-  }
-}
-
-export class ForbiddenError extends Error {
-  constructor(message = 'You are not allowed to do that.') {
-    super(message)
-    this.name = 'ForbiddenError'
-  }
-}
-
 /** The current Supabase access token, or null when nobody is signed in. */
 export async function getAccessToken(): Promise<string | null> {
   if (!supabase) return null
@@ -48,14 +34,29 @@ function joinUrl(path: string): string {
 }
 
 /**
- * `fetch` with the caller's identity attached.
+ * Fired when the backend refuses the session and refreshing it did not help.
  *
- * Pass a path (`/players/123`) and it is resolved against `NEXT_PUBLIC_API_URL`; pass a
- * full URL and it is used as-is.
+ * `UnifiedAuthProvider` listens for this and signs the user out. Dispatching an event
+ * rather than redirecting from here keeps this module free of a dependency on the auth
+ * service, which imports it.
  */
-export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const token = await getAccessToken()
+export const SESSION_EXPIRED_EVENT = 'handoffate:session-expired'
 
+/** Guards against a burst of parallel 401s each announcing the same dead session. */
+let expiryAnnounced = false
+
+function announceSessionExpired(): void {
+  if (typeof window === 'undefined' || expiryAnnounced) return
+  expiryAnnounced = true
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT))
+}
+
+/** Call after a successful sign-in so a later expiry is announced again. */
+export function resetSessionExpiry(): void {
+  expiryAnnounced = false
+}
+
+function withAuth(init: RequestInit, token: string | null): RequestInit {
   const headers = new Headers(init.headers)
   if (token) {
     headers.set('Authorization', `Bearer ${token}`)
@@ -63,30 +64,48 @@ export async function apiFetch(path: string, init: RequestInit = {}): Promise<Re
   if (init.body !== undefined && !headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json')
   }
-
-  return fetch(joinUrl(path), { ...init, headers })
+  return { ...init, headers }
 }
 
 /**
- * `apiFetch` that returns parsed JSON and turns the two rejections worth distinguishing
- * into named errors, so callers can tell "sign in again" from "not yours to touch".
+ * `fetch` with the caller's identity attached.
+ *
+ * Pass a path (`/players/123`) and it is resolved against `NEXT_PUBLIC_API_URL`; pass a
+ * full URL and it is used as-is.
+ *
+ * A 401 is worth one retry: Supabase refreshes access tokens on its own, but a tab left
+ * open across the expiry can still send the stale one. If a forced refresh produces a
+ * different token the request goes again; if the answer is still 401 the session is
+ * genuinely gone and that is announced rather than handed back to the caller as another
+ * "failed to fetch", which is what left people staring at errors with no way out.
  */
-export async function apiFetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await apiFetch(path, init)
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = await getAccessToken()
+  const url = joinUrl(path)
+
+  let response = await fetch(url, withAuth(init, token))
+  if (response.status !== 401) {
+    return response
+  }
+
+  const refreshed = token ? await forceRefresh() : null
+  if (refreshed && refreshed !== token) {
+    response = await fetch(url, withAuth(init, refreshed))
+  }
 
   if (response.status === 401) {
-    throw new UnauthorizedError()
+    announceSessionExpired()
   }
-  if (response.status === 403) {
-    throw new ForbiddenError()
-  }
-  if (!response.ok) {
-    const body = await response.text().catch(() => '')
-    throw new Error(body || `Request to ${path} failed with ${response.status}`)
-  }
+  return response
+}
 
-  if (response.status === 204) {
-    return undefined as T
+async function forceRefresh(): Promise<string | null> {
+  if (!supabase) return null
+  try {
+    const { data, error } = await supabase.auth.refreshSession()
+    if (error) return null
+    return data.session?.access_token ?? null
+  } catch {
+    return null
   }
-  return (await response.json()) as T
 }

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -46,6 +46,15 @@ export interface AuthResponse {
   user: User | null
   session: Session | null
   error: any
+  /**
+   * Set when the address already has an account.
+   *
+   * Supabase answers a duplicate sign-up with 200, no error, and a user object
+   * carrying a plausible-looking `confirmation_sent_at` — deliberately, so the form
+   * cannot be used to discover who is registered. Nothing is sent. Only the empty
+   * `identities` array gives it away.
+   */
+  alreadyRegistered?: boolean
 }
 
 export type { User, Session, SupabaseClient }

--- a/frontend/src/services/supabaseAuthService.ts
+++ b/frontend/src/services/supabaseAuthService.ts
@@ -34,12 +34,14 @@ export class SupabaseAuthService {
         return { user: null, session: null, error }
       }
 
-      // If user needs to verify email
-      if (data.user && !data.user.email_confirmed_at) {
+      // An existing address comes back as a success with no identities attached. Left
+      // unread, the caller goes on to promise an email that Supabase never sent.
+      if (data.user && (data.user.identities?.length ?? 0) === 0) {
         return {
-          user: data.user,
-          session: data.session,
-          error: null
+          user: null,
+          session: null,
+          error: null,
+          alreadyRegistered: true
         }
       }
 

--- a/frontend/src/services/unifiedAuthService.ts
+++ b/frontend/src/services/unifiedAuthService.ts
@@ -49,6 +49,15 @@ export class UnifiedAuthService {
         }
       }
 
+      if (result.alreadyRegistered) {
+        return {
+          success: false,
+          alreadyRegistered: true,
+          error: 'That email already has an account. Sign in instead, or reset your password.',
+          needsEmailVerification: false
+        }
+      }
+
       // Check if email verification is needed
       if (result.user && !result.user.email_confirmed_at) {
         return {

--- a/infra/backup/Dockerfile
+++ b/infra/backup/Dockerfile
@@ -1,0 +1,30 @@
+# Takes a mongodump of Atlas and streams it straight into S3.
+#
+# There is no official image carrying both mongodump and the AWS CLI, and the two
+# have to be in the same container: the dump is piped rather than written to disk,
+# so nothing large ever lands on an instance with 30 GB of root volume and four
+# other containers on it.
+#
+# arm64, like everything else here — the deploy target is Graviton.
+FROM amazon/aws-cli:2.27.49
+
+# mongodump ships in mongodb-database-tools, not in the server packages. The base
+# image is Amazon Linux 2, so this is the amazon/2 repo and yum rather than dnf.
+# MongoDB only publishes 8.0 for Amazon Linux 2023; the 7.0 repo is what exists for
+# 2, and the tools in it are versioned separately and speak to an 8.0 server.
+RUN printf '%s\n' \
+      '[mongodb-org-7.0]' \
+      'name=MongoDB Repository' \
+      'baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/7.0/aarch64/' \
+      'gpgcheck=1' \
+      'enabled=1' \
+      'gpgkey=https://pgp.mongodb.com/server-7.0.asc' \
+      > /etc/yum.repos.d/mongodb-org-7.0.repo \
+ && yum install -y mongodb-database-tools gzip \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh
+
+ENTRYPOINT ["/usr/local/bin/backup.sh"]

--- a/infra/backup/backup.sh
+++ b/infra/backup/backup.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Dump MongoDB and put the archive in S3.
+#
+# Reads MONGODB_URI (from SSM, the same parameter the backend uses) and
+# BACKUP_BUCKET. Nothing is written to disk on the way out: mongodump writes the
+# archive to stdout and the AWS CLI reads it from stdin, so the size of the database
+# is not also a demand on an instance that has four other containers on it.
+set -eu
+
+: "${MONGODB_URI:?MONGODB_URI is not set}"
+: "${BACKUP_BUCKET:?BACKUP_BUCKET is not set}"
+
+# Check the tools before anything is written. A verification step that cannot run
+# looks exactly like a failed verification, and the response to that is to delete
+# the archive — so a missing binary would quietly throw away good backups.
+for tool in mongodump aws gzip; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "${tool} is not installed" >&2; exit 1; }
+done
+
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+KEY="mongodb/$(date -u +%Y/%m/%d)/card_game-${STAMP}.archive.gz"
+TARGET="s3://${BACKUP_BUCKET}/${KEY}"
+
+echo "Dumping to ${TARGET}"
+
+discard() {
+  echo "Removing the unusable archive" >&2
+  aws s3 rm "$TARGET" || true
+}
+
+# pipefail is not in POSIX sh, so a mongodump that died mid-stream would leave a
+# truncated archive behind that the pipeline reports as a success. Carry its exit
+# status out of the subshell by hand — with errexit off inside the group, or the
+# subshell would leave before recording anything.
+STATUS_FILE=$(mktemp)
+echo 1 > "$STATUS_FILE"
+{
+  set +e
+  mongodump --uri="$MONGODB_URI" --archive --gzip --quiet
+  echo $? > "$STATUS_FILE"
+} | aws s3 cp - "$TARGET"
+
+STATUS=$(cat "$STATUS_FILE")
+if [ "$STATUS" -ne 0 ]; then
+  echo "mongodump failed with status ${STATUS}" >&2
+  discard
+  exit "$STATUS"
+fi
+
+SIZE=$(aws s3api head-object --bucket "$BACKUP_BUCKET" --key "$KEY" \
+  --query ContentLength --output text)
+
+# Read it back and check the compressed stream runs to a clean end. Truncation is
+# the failure this whole pipeline invites, and it is the one a size threshold
+# cannot see: a half-written archive of a large database still looks big. Size is
+# no guide either way, since a legitimately small database makes a small archive.
+if ! aws s3 cp "$TARGET" - | gzip -t 2>/dev/null; then
+  echo "Archive does not decompress cleanly, so it is not a backup" >&2
+  discard
+  exit 1
+fi
+
+echo "Wrote and verified ${SIZE} bytes at ${TARGET}"

--- a/infra/ecs/README.md
+++ b/infra/ecs/README.md
@@ -85,7 +85,15 @@ aws cloudformation deploy \
       SubnetId=subnet-xxxxxxxx \
       BackendImage=<account>.dkr.ecr.us-west-2.amazonaws.com/hand-of-fate/backend:latest \
       SupabaseJwksUri=https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json \
-      SupabaseJwtIssuer=https://<project-ref>.supabase.co/auth/v1
+      SupabaseJwtIssuer=https://<project-ref>.supabase.co/auth/v1 \
+      DataVolumeAvailabilityZone=us-west-2a
+```
+
+`DataVolumeAvailabilityZone` has to be the zone `SubnetId` sits in — an EBS volume
+only attaches within its own zone. Check it with:
+
+```bash
+aws ec2 describe-subnets --subnet-ids <subnet> --query 'Subnets[0].AvailabilityZone'
 ```
 
 The two Supabase values are not secrets and so are stack parameters rather than
@@ -122,6 +130,31 @@ The `Deploy backend` GitHub Actions workflow does the same three steps — build
 arm64, push to ECR, roll the service — but only when you run it by hand, and
 only once an OIDC role ARN is in the `AWS_DEPLOY_ROLE_ARN` secret. It is manual
 on purpose: see below.
+
+### The data volume
+
+Nakama's Postgres lives on an EBS volume separate from the instance, mounted at
+`/var/lib/hand-of-fate`. It used to sit on the root volume, which the auto scaling
+group discards when it replaces the instance — so the mechanism that keeps the
+service alive was also the one that destroyed its data.
+
+The volume is `Retain` on both delete and replace: losing accounts and leaderboards
+to a `cloudformation delete` would be worse than leaving a volume behind. If you
+tear the stack down, delete it by hand once you are sure.
+
+The instance claims the volume in user data, the same way it claims the elastic IP,
+and refuses to start ECS if the mount is not there — an instance running tasks
+without it would quietly start a fresh Postgres on the root disk and look healthy
+while doing it.
+
+**Deploying this does not move existing data.** Changing the launch template leaves
+the running instance alone; the volume is only picked up by the next instance, and
+whatever was on the old root disk goes with it. Terminate the instance when you are
+ready to take that loss:
+
+```bash
+aws ec2 terminate-instances --instance-ids <id>   # the ASG brings back a replacement
+```
 
 There is one instance and the task uses host networking, so two copies cannot
 run at once. The service is set to `MinimumHealthyPercent: 0` — a deploy takes

--- a/infra/ecs/README.md
+++ b/infra/ecs/README.md
@@ -131,6 +131,49 @@ arm64, push to ECR, roll the service — but only when you run it by hand, and
 only once an OIDC role ARN is in the `AWS_DEPLOY_ROLE_ARN` secret. It is manual
 on purpose: see below.
 
+### Backups
+
+Atlas M0 has no backups and no setting to turn them on, so the player data had no
+recovery path at all. A scheduled ECS task now runs `mongodump` every night and
+streams the archive straight into S3 — nothing is written to the instance's disk on
+the way through.
+
+It runs on the existing instance on purpose: Atlas restricts access by IP and that
+instance's elastic IP is already on the list, which a GitHub Actions runner's
+address never would be.
+
+Build and push the image, then point the stack at it:
+
+```bash
+cd infra/backup
+docker build --platform linux/arm64 -t hand-of-fate-backup .
+docker tag hand-of-fate-backup:latest <account>.dkr.ecr.us-west-2.amazonaws.com/hand-of-fate/backup:latest
+docker push <account>.dkr.ecr.us-west-2.amazonaws.com/hand-of-fate/backup:latest
+
+aws cloudformation deploy ... --parameter-overrides \
+  BackupImage=<account>.dkr.ecr.us-west-2.amazonaws.com/hand-of-fate/backup:latest
+```
+
+`BackupImage` is empty by default and every backup resource is conditional on it,
+so a stack without the image deploys as before. The ECR repository needs creating
+once: `aws ecr create-repository --repository-name hand-of-fate/backup`.
+
+Archives land at `s3://hand-of-fate-backups-<account>/mongodb/YYYY/MM/DD/`, expire
+after `BackupRetentionDays` (30 by default), and the bucket is `Retain` so a stack
+teardown does not take the backups with it.
+
+Restoring, given an archive key:
+
+```bash
+aws s3 cp s3://hand-of-fate-backups-<account>/mongodb/2026/08/16/card_game-....archive.gz - \
+  | mongorestore --uri="<atlas-uri-without-a-database>" --archive --gzip \
+      --nsFrom='card_game.*' --nsTo='card_game_restored.*'
+```
+
+Restore beside the live database rather than over it, and swap once you have looked
+at what came back. Note the URI must not name a database — mongorestore scopes
+itself to it and the namespace remapping then silently restores nothing.
+
 ### The data volume
 
 Nakama's Postgres lives on an EBS volume separate from the instance, mounted at

--- a/infra/ecs/cloudformation.yml
+++ b/infra/ecs/cloudformation.yml
@@ -99,6 +99,30 @@ Parameters:
       Nakama's Postgres. It holds accounts and leaderboards for a game aiming at a
       hundred concurrent players, so this is sized for headroom rather than need.
 
+  BackupImage:
+    Type: String
+    Default: ""
+    Description: >
+      Full ECR image URI for the backup job, built from infra/backup. Leave empty to
+      deploy without scheduled backups.
+
+  BackupSchedule:
+    Type: String
+    Default: cron(0 9 * * ? *)
+    Description: >
+      When to run the backup, in UTC. The default is 09:00 UTC, which is the small
+      hours in US Pacific where the players are.
+
+  BackupRetentionDays:
+    Type: Number
+    Default: 30
+    MinValue: 1
+    Description: How long to keep an archive before S3 deletes it.
+
+Conditions:
+  # Everything to do with backups is skipped until an image exists to run.
+  BackupsEnabled: !Not [!Equals [!Ref BackupImage, ""]]
+
 Resources:
 
   # ---------------------------------------------------------------- logging
@@ -502,6 +526,136 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: cloudflared
+
+  # ------------------------------------------------------------- backups
+
+  # Atlas M0 has no backups and no way to turn them on, so the player data had no
+  # recovery path at all. A dump lands here every night.
+  BackupBucket:
+    Type: AWS::S3::Bucket
+    Condition: BackupsEnabled
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub ${ProjectName}-backups-${AWS::AccountId}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault: { SSEAlgorithm: AES256 }
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-archives
+            Status: Enabled
+            Prefix: mongodb/
+            ExpirationInDays: !Ref BackupRetentionDays
+          - Id: drop-old-versions
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 7
+          - Id: abandon-incomplete-uploads
+            Status: Enabled
+            AbortIncompleteMultipartUpload: { DaysAfterInitiation: 1 }
+
+  BackupTaskRole:
+    Type: AWS::IAM::Role
+    Condition: BackupsEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ecs-tasks.amazonaws.com }
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: write-backups
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # Write and read back what it just wrote, to check the size. No
+              # blanket delete: the only object it may remove is a partial archive
+              # under the prefix it owns.
+              - Effect: Allow
+                Action: [s3:PutObject, s3:GetObject, s3:DeleteObject]
+                Resource: !Sub ${BackupBucket.Arn}/mongodb/*
+
+  BackupTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Condition: BackupsEnabled
+    Properties:
+      Family: !Sub ${ProjectName}-backup
+      NetworkMode: host
+      RequiresCompatibilities: [EC2]
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt BackupTaskRole.Arn
+      ContainerDefinitions:
+        - Name: backup
+          Image: !Ref BackupImage
+          Essential: true
+          # Runs beside the live stack on a 2 GiB box, so it gets what is spare.
+          # The dump is streamed, never buffered to disk or held in memory.
+          MemoryReservation: 64
+          Memory: 200
+          Environment:
+            - { Name: BACKUP_BUCKET, Value: !Ref BackupBucket }
+          Secrets:
+            # The same connection string the backend uses. Read access to Atlas is
+            # all a dump needs, and it is already granted to this instance's IP.
+            - Name: MONGODB_URI
+              ValueFrom: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MongoUriParameter}
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: backup
+
+  BackupSchedulerRole:
+    Type: AWS::IAM::Role
+    Condition: BackupsEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: events.amazonaws.com }
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: run-backup-task
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ecs:RunTask
+                Resource: !Ref BackupTaskDefinition
+                Condition:
+                  ArnEquals: { ecs:cluster: !GetAtt Cluster.Arn }
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource:
+                  - !GetAtt TaskExecutionRole.Arn
+                  - !GetAtt BackupTaskRole.Arn
+
+  BackupScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: BackupsEnabled
+    Properties:
+      Name: !Sub ${ProjectName}-backup
+      Description: Nightly mongodump of Atlas into S3.
+      ScheduleExpression: !Ref BackupSchedule
+      State: ENABLED
+      Targets:
+        - Id: backup-task
+          Arn: !GetAtt Cluster.Arn
+          RoleArn: !GetAtt BackupSchedulerRole.Arn
+          EcsParameters:
+            TaskDefinitionArn: !Ref BackupTaskDefinition
+            TaskCount: 1
+            LaunchType: EC2
 
   Service:
     Type: AWS::ECS::Service

--- a/infra/ecs/cloudformation.yml
+++ b/infra/ecs/cloudformation.yml
@@ -93,11 +93,13 @@ Parameters:
 
   DataVolumeSizeGb:
     Type: Number
-    Default: 8
+    Default: 4
     MinValue: 4
     Description: >
-      Nakama's Postgres. It holds accounts and leaderboards for a game aiming at a
-      hundred concurrent players, so this is sized for headroom rather than need.
+      Nakama's Postgres, which holds accounts and leaderboards. Four gigabytes is far
+      more than a game aiming at a hundred concurrent players will put in it, and gp3
+      bills per provisioned gigabyte whether or not it is used. Raising it later is a
+      parameter change; the filesystem needs growing to match.
 
   BackupImage:
     Type: String

--- a/infra/ecs/cloudformation.yml
+++ b/infra/ecs/cloudformation.yml
@@ -85,6 +85,20 @@ Parameters:
       Supabase user ids allowed to reach /admin/**. Empty means nobody is, and the
       admin endpoints answer 403 to every caller.
 
+  DataVolumeAvailabilityZone:
+    Type: AWS::EC2::AvailabilityZone::Name
+    Description: >
+      Must be the availability zone SubnetId lives in — an EBS volume can only attach
+      to an instance in its own zone.
+
+  DataVolumeSizeGb:
+    Type: Number
+    Default: 8
+    MinValue: 4
+    Description: >
+      Nakama's Postgres. It holds accounts and leaderboards for a game aiming at a
+      hundred concurrent players, so this is sized for headroom rather than need.
+
 Resources:
 
   # ---------------------------------------------------------------- logging
@@ -113,7 +127,7 @@ Resources:
         # Shell access without opening port 22.
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
-        - PolicyName: claim-elastic-ip
+        - PolicyName: claim-elastic-ip-and-data-volume
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -121,6 +135,10 @@ Resources:
               # instance comes back on the same address Atlas already trusts.
               - Effect: Allow
                 Action: [ec2:AssociateAddress, ec2:DescribeAddresses]
+                Resource: "*"
+              # Same idea for the data volume: a replaced instance picks it back up.
+              - Effect: Allow
+                Action: [ec2:AttachVolume, ec2:DescribeVolumes]
                 Resource: "*"
 
   InstanceProfile:
@@ -193,6 +211,24 @@ Resources:
         - Key: Name
           Value: !Sub ${ProjectName}-stable-egress
 
+  # Nakama's Postgres used to live on the instance's root volume, which the auto
+  # scaling group throws away whenever it replaces the instance — so the mechanism
+  # meant to keep the service alive was also what destroyed its data. This volume
+  # outlives the instance, and outlives the stack: losing accounts and leaderboards
+  # to a `cloudformation delete` would be worse than leaving a volume behind.
+  DataVolume:
+    Type: AWS::EC2::Volume
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      AvailabilityZone: !Ref DataVolumeAvailabilityZone
+      Size: !Ref DataVolumeSizeGb
+      VolumeType: gp3
+      Encrypted: true
+      Tags:
+        - Key: Name
+          Value: !Sub ${ProjectName}-data
+
   LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:
@@ -213,6 +249,9 @@ Resources:
         UserData:
           Fn::Base64: !Sub |
             #!/bin/bash
+            set -x
+            # The agent is held back until the data volume is mounted, further down.
+            systemctl stop ecs || true
             echo "ECS_CLUSTER=${ProjectName}" >> /etc/ecs/ecs.config
             echo "ECS_ENABLE_CONTAINER_METADATA=true" >> /etc/ecs/ecs.config
 
@@ -234,10 +273,39 @@ Resources:
             swapon /swapfile
             echo "/swapfile none swap sw 0 0" >> /etc/fstab
 
-            # Nakama's Postgres data lives on the host so it survives task
-            # restarts. It does not survive instance replacement — acceptable
-            # here because Nakama accounts are recreated on login.
+            # Nakama's Postgres lives on a volume of its own so it survives both
+            # task restarts and instance replacement. ECS is told to wait: a
+            # container that started against an empty mount point would initialise
+            # a fresh database on top of the real one.
+            VOL=${DataVolume}
+            aws ec2 attach-volume --region ${AWS::Region} \
+              --volume-id "$VOL" --instance-id "$IID" --device /dev/sdf
+
+            # Nitro exposes EBS as NVMe under a name that has nothing to do with
+            # the one requested above; the by-id link is the reliable handle.
+            DEV=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_$(echo "$VOL" | tr -d '-')
+            for _ in $(seq 1 60); do [ -e "$DEV" ] && break; sleep 2; done
+
+            # A brand new volume has no filesystem. An existing one must never be
+            # reformatted, so only make one when blkid finds nothing at all.
+            if ! blkid "$DEV" >/dev/null 2>&1; then
+              mkfs.ext4 -L hand-of-fate-data "$DEV"
+            fi
+
+            mkdir -p /var/lib/hand-of-fate
+            echo "LABEL=hand-of-fate-data /var/lib/hand-of-fate ext4 defaults,nofail 0 2" >> /etc/fstab
+            mount /var/lib/hand-of-fate
+
+            # An instance that runs tasks without the volume would quietly start a
+            # brand new Postgres on the root disk and look perfectly healthy while
+            # doing it. Better to sit here doing nothing and be noticed.
+            if ! mountpoint -q /var/lib/hand-of-fate; then
+              echo "data volume is not mounted; not starting ECS" >&2
+              exit 1
+            fi
+
             mkdir -p /var/lib/hand-of-fate/postgres
+            systemctl start ecs
         TagSpecifications:
           - ResourceType: instance
             Tags:

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -63,6 +63,10 @@ services:
 
   nakama:
     container_name: nakama
+    # The server key has to be set here as well as on the backend. Production passes it
+    # to both; this file used to pass it only to the backend, so Nakama fell back to its
+    # built-in "defaultkey" and every local run agreed with the backend no matter what
+    # the backend was configured with. A key mismatch could not be reproduced.
     # 3.26.0 is the earliest tag published for arm64; anything older is
     # amd64-only and will not run on Graviton without emulation.
     image: registry.heroiclabs.com/heroiclabs/nakama:3.26.0
@@ -75,6 +79,7 @@ services:
         exec /nakama/nakama
         --name nakama1
         --database.address postgres:${POSTGRES_PASSWORD:-localdb}@postgres:5432/nakama
+        --socket.server_key ${NAKAMA_SERVER_KEY:-defaultkey}
         --logger.level INFO
         --session.token_expiry_sec 7200
     depends_on:


### PR DESCRIPTION
Seven commits, in three groups. Everything here was verified against something real — a live Supabase project, a running Nakama, an actual mongodump restored and compared — rather than only compiled.

## Signup and sessions

**Supabase answers a duplicate sign-up with a success.** Status 200, no error, a user object, and a plausible `confirmation_sent_at` — deliberately, so the form cannot be used to discover who is registered. Nothing is sent. The only tell is an empty `identities` array, which nothing was reading, so the form said "check your email" and the person waited forever. This is very likely what was actually being hit when signups appeared to send no mail.

**Nothing handled a 401.** Once a session was past saving, every call came back as another "failed to fetch" and the user was left clicking around a signed-in UI that no longer worked. `apiFetch` now forces one refresh and retries — a tab left open across the expiry can still hold the stale token — and if the answer is still 401 the auth provider signs out. This also removes `apiFetchJson` and its two error types, which were added with the bearer-token work in #33 and never called by anything.

## Two ways to lose data

**Nakama's Postgres sat on the instance's root volume.** The auto scaling group discards it when it replaces the instance, so the mechanism keeping the service alive was also the one destroying its data. It now lives on an EBS volume the instance claims at boot, `Retain` on delete and replace. User data refuses to start ECS if the mount is missing, because an instance that ran tasks anyway would initialise a fresh Postgres on the root disk and look perfectly healthy doing it.

**Atlas M0 has no backups and no way to enable them.** A scheduled ECS task now dumps to S3 nightly, streamed rather than written to disk. It runs on the existing instance because Atlas restricts by IP and that instance's elastic IP is already trusted, where a CI runner's address never would be.

The verification step is deliberate. Truncation is the failure a pipeline like this invites and it is the one a size check cannot see — half of a large database still looks big, while a small database legitimately produces a small archive. So the archive is read back and decompressed before the job reports success. Two mistakes were made building this and are worth knowing about:

- A "smaller than 1KB means failure" threshold flagged a 974-byte archive that was simply a correct dump of a small database. It would have alerted every night.
- `gzip` was not in the image, and "command not found" is indistinguishable from "archive is corrupt" — so it deleted a perfectly good backup. The job now checks its tools before writing anything, since the response to a failed verification is deletion.

## A bug that could not be reproduced locally

**The leaderboard service read `nakama.serverKey`; the property is `nakama.server.key`.** Nothing defines the camelCase one, so it silently took the default `defaultkey` and production logged `UNAUTHENTICATED: Server key invalid` on every boot since forever. Scores are submitted when a game ends, so **no completed game has ever recorded one**.

It now takes the `Client` bean `NakamaConfig` already builds instead of assembling a second one from its own copy of host, port, ssl and key — which is where the typo had room to hide. It also authenticated as a fresh random device id on every start, leaving another Nakama account behind on each restart and redeploy; one stable id reuses the same one.

A separate commit fixes why this survived: **the local compose never passed `--socket.server_key` to Nakama**, so local Nakama always used its built-in default and agreed with the backend no matter what the backend was told to use. Production passes it to both. The mismatch was not reproducible until now.

## Verified

- Duplicate sign-up: real Supabase account, real browser, real form — shows "already has an account" and moves to sign-in. New addresses still get `identities: 1` and the normal verification path.
- 401: local frontend against the **production** backend, 401 forced at the network layer — redirects to `/login`, logs `Session expired, signing out`.
- Nakama key: local Nakama and backend both set to a non-default key. Fails before, `Leaderboard service authenticated with Nakama` after, clean boot with zero errors.
- Backups: MinIO as a real S3 endpoint. Success exits 0, an unreachable database exits 1 and removes the partial archive, and **the archive was downloaded and restored — 19 documents across four collections, identical to the source**.
- Backend suite green, frontend type-checks, lints and builds. CloudFormation validates.

## Deploying

Two things do not take effect on their own:

1. **The EBS volume waits for the next instance.** Changing the launch template leaves the running instance alone; the volume is picked up by its replacement, and whatever is on the old root disk goes with it. Terminate the instance when ready to accept that.
2. **Backups need the image first.** `BackupImage` is empty by default and every backup resource is conditional on it, so the stack deploys as before until `infra/backup` is built and pushed. The ECR repository needs creating once.

Also new: `DataVolumeAvailabilityZone`, which must match the subnet's zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)