### PR TITLE
Keep the data volume's label inside ext4's limit

### DIFF
--- a/infra/ecs/cloudformation.yml
+++ b/infra/ecs/cloudformation.yml
@@ -314,12 +314,15 @@ Resources:
 
             # A brand new volume has no filesystem. An existing one must never be
             # reformatted, so only make one when blkid finds nothing at all.
+            # ext4 labels are capped at 16 characters and mkfs truncates past that
+            # without failing, so a longer name here would not match the fstab entry
+            # below and the mount would fail on a filesystem that looked fine.
             if ! blkid "$DEV" >/dev/null 2>&1; then
-              mkfs.ext4 -L hand-of-fate-data "$DEV"
+              mkfs.ext4 -L hand-of-fate "$DEV"
             fi
 
             mkdir -p /var/lib/hand-of-fate
-            echo "LABEL=hand-of-fate-data /var/lib/hand-of-fate ext4 defaults,nofail 0 2" >> /etc/fstab
+            echo "LABEL=hand-of-fate /var/lib/hand-of-fate ext4 defaults,nofail 0 2" >> /etc/fstab
             mount /var/lib/hand-of-fate
 
             # An instance that runs tasks without the volume would quietly start a


### PR DESCRIPTION
Follow-up to #34, found by deploying it.

`mkfs.ext4` caps labels at sixteen characters and **truncates past that with a warning rather than an error**, so `hand-of-fate-data` (seventeen) landed on disk as `hand-of-fate-dat` while the fstab entry went on asking for the full name. The mount failed on a filesystem that was otherwise perfectly good.

The guard added in #34 then did exactly what it was built for — refused to start ECS rather than let Postgres initialise a fresh database on the root disk and look healthy doing it. It cost a few minutes of API downtime and saved the failure mode that would have been much harder to notice.

Label is now `hand-of-fate`, twelve characters. The running instance has been relabelled and its fstab corrected to match, so it and the template agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)