### PR TITLE
Alarm when the service stops, and a load test that says why it would

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,26 +89,49 @@ one game at a time, `convertToDto` re-reads every player on every state
 conversion (and that runs once per connected socket per move), and finishing a
 game has to "restore" the player's original deck — a crash mid-game loses it.
 
-**Online matches are in-memory.** `NakamaMatchService` keeps matches in a
-`ConcurrentHashMap` and never uses Nakama's match API despite the dependency.
-A restart drops every active match, and the design cannot survive a second
-instance. `getMatchState` scans the entire games collection on every call.
+**Online matches are in-memory, and they are never released.** `NakamaMatchService`
+keeps matches in a `ConcurrentHashMap` and never uses Nakama's match API despite the
+dependency. A restart drops every active match, and the design cannot survive a
+second instance. `getMatchState` scans the entire games collection on every call.
+
+`cleanupMatch` exists to empty `matchMetadata`, `matchSubscriptions` and
+`activeSockets` for a finished match, and **nothing calls it**. A completed game
+leaves its entries behind for the life of the process; `handleGameAction` logs the
+completion and returns. This is measured, not suspected — see below.
+
+**The backend runs out of memory at 100 concurrent players.** `loadtest/` drives
+50 concurrent games over 100 WebSocket sessions. On a clean database it holds up:
+3,294 moves, no errors, p50 16 ms and p99 510 ms for a move to reach the opponent.
+The memory does not come back afterwards — the process finished that run sitting at
+636 MiB — and a second identical run against the same process is OOM-killed at the
+768 MiB the production task allocates, roughly forty seconds in. `OOMKilled=true`,
+exit 137, reproduced twice.
+
+The p99 is 32× the p50 even in the run that succeeded, which is the read
+amplification above rather than anything the machine ran out of. Both numbers come
+from an Apple Silicon laptop against a local MongoDB, so they are not production
+latencies; they are a baseline to compare the next change against.
 
 **No concurrency control.** No `@Version` on documents, no transactions.
 Simultaneous writes overwrite each other.
 
 **Nothing notices a wedged application.** The auto scaling group's health check is
 `EC2`, which sees a dead instance and nothing else. A backend that is running but
-answering nothing is invisible to it, and there is no alarm anywhere else either —
-the way you find out the site is down is by looking at it. It has already happened
-once, during the deploy that moved Nakama's Postgres onto its own volume.
+answering nothing is invisible to it. It has already caught nobody out once, during
+the deploy that moved Nakama's Postgres onto its own volume.
 
-Two cheap things fix the part that matters, and neither is a metrics stack:
+`ServiceStoppedAlarm` in `infra/ecs/cloudformation.yml` now covers half of this: it
+watches `AWS/ECS` `LiveTaskCount`, which is published every minute *without*
+Container Insights — that is what makes it free, since Container Insights is billed
+per metric and stays disabled on the cluster. Five evaluation periods, because a
+deploy legitimately sits at zero tasks for two to four minutes. It emails the
+address in the `AlertEmail` parameter through SNS.
 
-- an external uptime check on `https://handoffate.org` and
-  `https://api.handoffate.org/actuator/health`, which is the only thing that would
-  have said anything during that outage;
-- a CloudWatch alarm on the ECS service's `runningCount` dropping below one.
+What is still missing is the half that catches a backend answering nothing while
+its task is happily running — an external uptime check on `https://handoffate.org`
+and `https://api.handoffate.org/actuator/health`. That is the only thing that would
+have said anything during the outage above, and it wants a third-party monitor
+rather than anything in this template.
 
 **Prometheus and Grafana are not the answer to this, yet.** They draw graphs; they
 do not tell anyone. `infra/monitoring` still holds the old setup and it is tempting
@@ -193,10 +216,15 @@ session is a judgement call that changes with what the project needs next.
    possible.
 4. **Make matches survive a restart.** Either commit to Nakama's match API or
    persist match state properly. Add optimistic locking while here.
-5. **Hold 100 concurrent players.** Only meaningful once the above lands — load
-   test, fix what it finds, decide whether one `t4g.small` is still the right
-   size. This is where Prometheus and Grafana earn their keep; bringing them back
-   before there is load to watch buys a flat line and a memory bill.
+5. **Hold 100 concurrent players.** The load test exists now (`loadtest/`) and it
+   already answers what gives out first: memory, at the 768 MiB the production
+   task allocates, because finished matches are never released. That is item 4,
+   so the order above still holds — but 4 now has a number attached and a way to
+   tell whether fixing it worked. What is left here afterwards is re-running it,
+   deciding whether one `t4g.small` is still the right size, and only then asking
+   whether Prometheus and Grafana are worth the money. They are not yet: the
+   question "which resource gives out first" got answered by `docker stats` and a
+   container exit code.
 6. **Frontend.** Break up the 900-line components, fix reconnection, delete the
    dead services. (The home page's Power Score is real data, not a placeholder —
    that item was stale.)

--- a/infra/ecs/cloudformation.yml
+++ b/infra/ecs/cloudformation.yml
@@ -121,9 +121,19 @@ Parameters:
     MinValue: 1
     Description: How long to keep an archive before S3 deletes it.
 
+  AlertEmail:
+    Type: String
+    Default: ""
+    Description: >
+      Where to send an alert when the service stops running. SNS sends a
+      confirmation link to this address first, and delivers nothing until it is
+      clicked. Leave empty to create the alarm without anywhere to send it.
+
 Conditions:
   # Everything to do with backups is skipped until an image exists to run.
   BackupsEnabled: !Not [!Equals [!Ref BackupImage, ""]]
+
+  AlertEmailProvided: !Not [!Equals [!Ref AlertEmail, ""]]
 
 Resources:
 
@@ -679,6 +689,63 @@ Resources:
         MinimumHealthyPercent: 0
         MaximumPercent: 100
 
+  # ------------------------------------------------------------- alerting
+
+  AlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub ${ProjectName}-alerts
+      DisplayName: Hand of Fate
+
+  AlertEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: AlertEmailProvided
+    Properties:
+      TopicArn: !Ref AlertTopic
+      Protocol: email
+      Endpoint: !Ref AlertEmail
+
+  # Until this existed, the way anyone found out the service was gone was by
+  # opening the site. The auto scaling group's health check is EC2, which sees a
+  # dead instance and nothing else.
+  #
+  # LiveTaskCount is published into AWS/ECS every minute without Container
+  # Insights, which is what makes this free — Container Insights is billed per
+  # metric and is deliberately disabled on the cluster above.
+  #
+  # A stopped service publishes nothing at all rather than publishing a zero, so
+  # missing data has to count as breaching or the alarm would sit at
+  # INSUFFICIENT_DATA through the entire outage.
+  #
+  # Five minutes is chosen to ride out an ordinary deploy: the task starts
+  # postgres, then nakama, then the backend, each waiting on the previous one's
+  # health check, and MinimumHealthyPercent is 0, so the count legitimately sits
+  # at zero for two to four minutes every time. A deploy slower than five
+  # minutes has gone wrong and is worth hearing about.
+  ServiceStoppedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${ProjectName}-service-stopped
+      AlarmDescription: >-
+        No task has been running for the ECS service for five minutes. The site
+        is down.
+      Namespace: AWS/ECS
+      MetricName: LiveTaskCount
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref Cluster
+        - Name: ServiceName
+          Value: !GetAtt Service.Name
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
 Outputs:
   EgressIp:
     Description: Add this to the Atlas IP access list. It survives instance replacement.
@@ -691,3 +758,6 @@ Outputs:
     Value: !Ref LogGroup
   SecurityGroupId:
     Value: !GetAtt SecurityGroup.GroupId
+  AlertTopicArn:
+    Description: Point further alarms at this rather than creating a second topic.
+    Value: !Ref AlertTopic

--- a/loadtest/.gitignore
+++ b/loadtest/.gitignore
@@ -1,0 +1,5 @@
+# Generated on first run. The keypair signs load-test tokens only and protects
+# nothing, but there is no reason to carry it in git; players.json holds tokens for
+# whichever database was last seeded.
+keys/
+players.json

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,105 @@
+# Load test
+
+Measures how long a move takes to come back, under concurrent play.
+
+Two numbers, both timed from the moment the acting socket sends `GAME_ACTION`:
+
+| | |
+|---|---|
+| **action** | until the acting player's own `GAME_STATE_UPDATE` arrives |
+| **action→broadcast** | until the *opponent's* `GAME_STATE_UPDATE` arrives |
+
+The second decides whether the game feels real-time. It is also why this is a
+driver of its own rather than a k6 script: both halves have to be timed against
+one clock, so one process has to hold both sockets of a match.
+
+`GameWebSocketHandler.handleGameAction` serves both updates from one loop,
+calling `convertToDto` once per session in the match, and `convertToDto` re-reads
+every player. The gap between the two numbers is roughly one conversion — which
+makes it the read amplification, measured.
+
+## Do not point this at production
+
+`handoffate.org` sits behind a Cloudflare Tunnel and on an Atlas M0. You would be
+measuring Cloudflare and Atlas's shared-tier throttling rather than this code,
+you would be filling the production database with `loadtest_*` accounts, and one
+`t4g.small` serves the real site. Run it against a stack of your own.
+
+## Running it
+
+Four terminals, in order.
+
+**1. Serve the load-test signing key.** A hundred players signing in through the
+real Supabase project would hit its auth rate limits and leave a hundred junk
+accounts in the production user table. Instead the backend is pointed at a key
+that exists only here — `security.jwt.jwk-set-uri` is a plain environment
+variable, so nothing in the application has to change.
+
+```bash
+node loadtest/jwks-server.mjs
+```
+
+**2. Bring up a backend that trusts it.** In `infra/local/.env`:
+
+```
+SUPABASE_JWKS_URI=http://host.docker.internal:9999/.well-known/jwks.json
+SUPABASE_JWT_ISSUER=
+```
+
+`host.docker.internal` because the backend runs in a container, where
+`localhost` is the container. The empty issuer matters: `security.jwt.issuer` is
+only enforced when it is set, and these tokens carry no `iss`.
+
+```bash
+cd infra/local && docker compose up -d --force-recreate backend
+```
+
+Production gives the backend container 768 MiB and `infra/local` gives it 640.
+Raise `mem_limit` to `768m` before a run whose numbers you intend to compare
+against production, or the heap you measured is not the heap that ships.
+
+**3. Create the players.** Idempotent — re-running against a database that was
+not wiped reuses the same accounts.
+
+```bash
+PLAYERS=100 node loadtest/seed.mjs
+```
+
+Each player gets a Nakama account and a starting deck, so this takes a couple of
+minutes and is the reason seeding is a separate step from driving.
+
+**4. Drive it.**
+
+```bash
+GAMES=50 DURATION=60 node loadtest/drive.mjs
+```
+
+`GAMES=50` is 100 concurrent sockets, which is the 100 concurrent players in the
+goal. Everything is tunable: `DURATION` and `WARMUP` in seconds, `MOVE_INTERVAL`
+in milliseconds, `BASE_URL` for a backend that is not on `localhost:8080`.
+
+## Reading the result
+
+```
+                    count    mean     p50     p95     p99     max  (ms)
+action                812    14.3    11.2    28.7    46.1    91.4
+action→broadcast      812    19.8    16.4    38.2    61.7   118.3
+```
+
+`WARMUP` exists because the JVM serves the first moves through the interpreter;
+samples taken before the JIT settles describe a warm-up, not the system.
+
+`MOVE_INTERVAL` defaults to one second because real players do not spam. Dropping
+it measures saturation instead of latency under plausible load — a different and
+also useful question, but not the same one.
+
+Watch `rejected` and `errors` at the bottom. A run with a meaningful number of
+either is not a latency measurement, it is a bug report.
+
+## What the numbers are not
+
+A run on an Apple Silicon laptop against a local Mongo is faster than one
+`t4g.small` talking to Atlas across a network, so these are not production
+latencies and should not be quoted as such. What they are good for is comparison:
+the same harness before and after a change, on the same machine, says exactly
+what the change did.

--- a/loadtest/drive.mjs
+++ b/loadtest/drive.mjs
@@ -1,0 +1,269 @@
+// Drives N concurrent games and measures how long a move takes to come back.
+//
+// Two numbers, both timed from the instant the acting socket sends GAME_ACTION:
+//
+//   action           until the acting player's own GAME_STATE_UPDATE arrives
+//   action→broadcast until the opponent's GAME_STATE_UPDATE arrives
+//
+// The second is the one that decides whether the game feels real-time, and it is why
+// this is a bespoke driver rather than a k6 script: both halves have to be timed against
+// one clock, which means one process has to hold both sockets of a match.
+//
+// GameWebSocketHandler serves the two updates from the same loop, calling
+// convertToDto once per session in the match, so the gap between the two numbers is
+// roughly the cost of one conversion — which is the read amplification worth watching.
+//
+// Usage:
+//   node drive.mjs                      50 games (100 sockets), 60s
+//   GAMES=25 DURATION=120 node drive.mjs
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8080';
+const WS_URL = BASE_URL.replace(/^http/, 'ws') + '/ws/game';
+const GAMES = Number(process.env.GAMES ?? 50);
+const DURATION_MS = Number(process.env.DURATION ?? 60) * 1000;
+// The JVM serves the first moves through the interpreter. Anything sampled before the
+// JIT has settled describes a warm-up, not the system.
+const WARMUP_MS = Number(process.env.WARMUP ?? 15) * 1000;
+// Think time between moves. Real players do not spam; without this the test measures
+// saturation rather than latency under a plausible load.
+const MOVE_INTERVAL_MS = Number(process.env.MOVE_INTERVAL ?? 1000);
+
+const BOARD_WIDTH = 3;
+const BOARD_HEIGHT = 5;
+// GameService.placeInitialCards puts the creator here and the joiner opposite.
+const CREATOR_START = { x: 1, y: 3 };
+const JOINER_START = { x: 1, y: 1 };
+
+const players = JSON.parse(
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'players.json'), 'utf8'),
+);
+
+if (players.length < GAMES * 2) {
+    console.error(`need ${GAMES * 2} players for ${GAMES} games, players.json has ${players.length}`);
+    process.exit(1);
+}
+
+// A reply that never comes has to fail the pair rather than park it forever: the whole
+// point of the run is to find out when the server stops answering, and a driver that
+// hangs at that moment reports nothing.
+const REPLY_TIMEOUT_MS = Number(process.env.REPLY_TIMEOUT ?? 15) * 1000;
+
+const samples = { action: [], broadcast: [] };
+const counters = { moves: 0, games: 0, rejected: 0, errors: 0, timeouts: 0 };
+let recording = false;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const key = (pos) => `${pos.x},${pos.y}`;
+
+/** Every empty cell orthogonally adjacent to one this player already holds. */
+function legalMoves(own, occupied) {
+    const candidates = new Map();
+    for (const cell of own) {
+        const [x, y] = cell.split(',').map(Number);
+        for (const [dx, dy] of [[0, 1], [0, -1], [1, 0], [-1, 0]]) {
+            const pos = { x: x + dx, y: y + dy };
+            if (pos.x < 0 || pos.x >= BOARD_WIDTH || pos.y < 0 || pos.y >= BOARD_HEIGHT) continue;
+            if (occupied.has(key(pos))) continue;
+            candidates.set(key(pos), pos);
+        }
+    }
+    return [...candidates.values()];
+}
+
+/**
+ * A socket that resolves one waiter per message type.
+ *
+ * The driver only ever waits for the next update rather than correlating replies to
+ * requests, which is all the protocol allows: GAME_STATE_UPDATE carries no reference to
+ * the action that caused it. It is sound here because a match makes one move at a time.
+ */
+function connect(token) {
+    return new Promise((resolve, reject) => {
+        const socket = new WebSocket(WS_URL, { headers: { authorization: `Bearer ${token}` } });
+        const waiters = new Map();
+
+        socket.addEventListener('message', (event) => {
+            const message = JSON.parse(event.data);
+            const waiter = waiters.get(message.type);
+            if (waiter) {
+                waiters.delete(message.type);
+                waiter.deliver({ at: performance.now(), data: message.data });
+            }
+            if (message.type === 'ERROR') counters.rejected++;
+        });
+
+        socket.addEventListener('error', () => reject(new Error('socket error')));
+        socket.addEventListener('close', () => {
+            for (const [type, waiter] of waiters) waiter.fail(new Error(`socket closed waiting for ${type}`));
+            waiters.clear();
+        });
+        socket.addEventListener('open', () => resolve({
+            send: (type, data) => socket.send(JSON.stringify({ type, data })),
+            next: (type) => new Promise((resolveNext, rejectNext) => {
+                const timer = setTimeout(() => {
+                    waiters.delete(type);
+                    counters.timeouts++;
+                    rejectNext(new Error(`timed out waiting for ${type}`));
+                }, REPLY_TIMEOUT_MS);
+                waiters.set(type, {
+                    deliver: (value) => { clearTimeout(timer); resolveNext(value); },
+                    fail: (error) => { clearTimeout(timer); rejectNext(error); },
+                });
+            }),
+            close: () => socket.close(),
+        }));
+    });
+}
+
+async function post(path, token, body) {
+    const response = await fetch(`${BASE_URL}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify(body ?? {}),
+        signal: AbortSignal.timeout(REPLY_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`${path}: ${response.status} ${await response.text()}`);
+    return response.json();
+}
+
+/** One move, timed on both sockets. Returns false when the game can go no further. */
+async function playMove(actor, opponent, board) {
+    const moves = legalMoves(actor.own, board.occupied);
+    const hand = actor.hand;
+    if (moves.length === 0 || hand.length === 0) return false;
+
+    const card = hand[0];
+    const position = moves[0];
+
+    // Both waiters are armed before the send, or a fast reply could arrive first.
+    const ownUpdate = actor.socket.next('GAME_STATE_UPDATE');
+    const opponentUpdate = opponent.socket.next('GAME_STATE_UPDATE');
+
+    const sentAt = performance.now();
+    actor.socket.send('GAME_ACTION', {
+        action: {
+            type: 'PLACE_CARD',
+            card: { id: card.id, name: card.name, power: card.power },
+            targetPosition: position,
+        },
+    });
+
+    const [own, other] = await Promise.all([ownUpdate, opponentUpdate]);
+
+    if (recording) {
+        samples.action.push(own.at - sentAt);
+        samples.broadcast.push(other.at - sentAt);
+    }
+    counters.moves++;
+
+    actor.own.add(key(position));
+    board.occupied.add(key(position));
+    actor.hand = own.data?.currentPlayerHand ?? hand.slice(1);
+    opponent.hand = other.data?.currentPlayerHand ?? opponent.hand;
+    return true;
+}
+
+/** Creates a match, plays it to exhaustion, and reports whether to start another. */
+async function playGame(creator, joiner) {
+    const { matchId } = await post('/api/online-game/create', creator.token);
+    await post(`/api/online-game/join/${matchId}`, joiner.token);
+
+    const seats = [
+        { ...creator, socket: await connect(creator.token), own: new Set([key(CREATOR_START)]) },
+        { ...joiner, socket: await connect(joiner.token), own: new Set([key(JOINER_START)]) },
+    ];
+
+    try {
+        for (const seat of seats) {
+            const joined = seat.socket.next('JOIN_SUCCESS');
+            seat.socket.send('JOIN_MATCH', { matchId });
+            await joined;
+        }
+
+        // JOIN_MATCH answers with a seat, not a board. The hand has to be asked for.
+        for (const seat of seats) {
+            const state = seat.socket.next('GAME_STATE_UPDATE');
+            seat.socket.send('GAME_STATE_REQUEST', { matchId });
+            seat.hand = (await state).data?.currentPlayerHand ?? [];
+        }
+
+        const board = { occupied: new Set([key(CREATOR_START), key(JOINER_START)]) };
+        let turn = 0; // GameService starts the creator.
+
+        while (Date.now() < deadline) {
+            const played = await playMove(seats[turn], seats[1 - turn], board);
+            if (!played) break;
+            turn = 1 - turn;
+            await sleep(MOVE_INTERVAL_MS);
+        }
+        counters.games++;
+    } finally {
+        for (const seat of seats) seat.socket.close();
+    }
+}
+
+/** One pair of players, playing games back to back until the clock runs out. */
+async function runPair(creator, joiner) {
+    while (Date.now() < deadline) {
+        try {
+            await playGame(creator, joiner);
+        } catch (error) {
+            counters.errors++;
+            if (counters.errors <= 5) console.error(`  ${creator.name}: ${error.message}`);
+            await sleep(1000);
+        }
+    }
+}
+
+function percentile(sorted, p) {
+    if (sorted.length === 0) return NaN;
+    return sorted[Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)];
+}
+
+function report(label, values) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const mean = sorted.reduce((a, b) => a + b, 0) / sorted.length;
+    const ms = (n) => (Number.isNaN(n) ? '—' : n.toFixed(1).padStart(8));
+    console.log(
+        `${label.padEnd(18)}${String(sorted.length).padStart(7)}` +
+        `${ms(mean)}${ms(percentile(sorted, 50))}${ms(percentile(sorted, 95))}` +
+        `${ms(percentile(sorted, 99))}${ms(sorted[sorted.length - 1])}`,
+    );
+}
+
+const deadline = Date.now() + WARMUP_MS + DURATION_MS;
+
+console.log(`${GAMES} games / ${GAMES * 2} sockets against ${BASE_URL}`);
+console.log(`warmup ${WARMUP_MS / 1000}s, measuring ${DURATION_MS / 1000}s, ${MOVE_INTERVAL_MS}ms between moves\n`);
+
+setTimeout(() => {
+    recording = true;
+    console.log('warmup over, recording\n');
+}, WARMUP_MS);
+
+const pairs = [];
+for (let i = 0; i < GAMES; i++) {
+    pairs.push(runPair(players[i * 2], players[i * 2 + 1]));
+    // Opening a hundred sockets in the same tick measures the connect storm, not play.
+    await sleep(50);
+}
+
+await Promise.all(pairs);
+
+console.log(`\n${''.padEnd(18)}${'count'.padStart(7)}${'mean'.padStart(8)}${'p50'.padStart(8)}${'p95'.padStart(8)}${'p99'.padStart(8)}${'max'.padStart(8)}  (ms)`);
+report('action', samples.action);
+report('action→broadcast', samples.broadcast);
+console.log(
+    `\n${counters.moves} moves, ${counters.games} games, ${counters.rejected} rejected, ` +
+    `${counters.timeouts} timed out, ${counters.errors} errors`,
+);
+// A run that lost replies did not measure latency, it measured a failure. Say so rather
+// than leaving a healthy-looking percentile table to speak for itself.
+if (counters.timeouts > 0 || counters.errors > 0) {
+    console.log('\nThe server stopped answering during this run. The percentiles above');
+    console.log('describe only the moves that came back, and understate what happened.');
+}

--- a/loadtest/jwks-server.mjs
+++ b/loadtest/jwks-server.mjs
@@ -1,0 +1,34 @@
+// Serves the load-test signing key so the backend can verify tokens minted by token.mjs.
+//
+// Point a load-test backend at it and leave the issuer empty:
+//
+//   SUPABASE_JWKS_URI=http://host.docker.internal:9999/.well-known/jwks.json
+//   SUPABASE_JWT_ISSUER=
+//
+// host.docker.internal rather than localhost because the backend runs in a container
+// and localhost there is the container.
+
+import { createServer } from 'node:http';
+import { jwks } from './token.mjs';
+
+const PORT = Number(process.env.JWKS_PORT ?? 9999);
+const PATH = '/.well-known/jwks.json';
+
+const body = JSON.stringify(jwks());
+
+createServer((request, response) => {
+    if (request.url !== PATH) {
+        response.writeHead(404).end();
+        return;
+    }
+    response.writeHead(200, {
+        'content-type': 'application/json',
+        // Spring's NimbusJwtDecoder caches the key set, but a restarted backend refetches
+        // it and there is no reason to serve a stale copy through a proxy in between.
+        'cache-control': 'no-store',
+    });
+    response.end(body);
+}).listen(PORT, () => {
+    console.log(`JWKS on http://localhost:${PORT}${PATH}`);
+    console.log('Leave this running for as long as the backend is up.');
+});

--- a/loadtest/seed.mjs
+++ b/loadtest/seed.mjs
@@ -1,0 +1,71 @@
+// Creates the players the load test drives, and writes their ids and tokens to
+// players.json for drive.mjs to read.
+//
+// Seeding goes through /api/auth/sync-verified-user rather than writing to Mongo
+// directly, because that endpoint is also what gives each player a Nakama account and a
+// starting deck — a player inserted behind its back cannot join a match.
+//
+// It is idempotent: the endpoint returns the existing player when the Supabase id is
+// already known, so re-running it against a database that was not wiped is cheap and
+// safe. Run it against a load-test stack, never against production.
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mintToken } from './token.mjs';
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8080';
+const PLAYER_COUNT = Number(process.env.PLAYERS ?? 100);
+const OUTPUT = join(dirname(fileURLToPath(import.meta.url)), 'players.json');
+
+// Distinct from any real Supabase id, and stable across runs so re-seeding reuses the
+// same players instead of growing the collection every time.
+const supabaseUserId = (index) => `loadtest-${String(index).padStart(4, '0')}`;
+
+async function createPlayer(index) {
+    const token = mintToken(supabaseUserId(index));
+    const name = `loadtest_${String(index).padStart(4, '0')}`;
+
+    const response = await fetch(`${BASE_URL}/api/auth/sync-verified-user`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({ username: name, email: `${name}@loadtest.invalid` }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`${name}: ${response.status} ${await response.text()}`);
+    }
+
+    const body = await response.json();
+    const playerId = body.playerId ?? body.player?.id ?? body.id;
+    if (!playerId) {
+        throw new Error(`${name}: no player id in ${JSON.stringify(body)}`);
+    }
+    return { name, playerId, token };
+}
+
+// Nakama account creation is the slow part and it is per player, so seeding a hundred
+// serially takes minutes. Ten at a time is enough to hide the latency without turning
+// the seed itself into the load test.
+async function seed() {
+    const players = [];
+    const CONCURRENCY = 10;
+
+    for (let start = 0; start < PLAYER_COUNT; start += CONCURRENCY) {
+        const batch = [];
+        for (let i = start; i < Math.min(start + CONCURRENCY, PLAYER_COUNT); i++) {
+            batch.push(createPlayer(i));
+        }
+        players.push(...await Promise.all(batch));
+        process.stdout.write(`\rseeded ${players.length}/${PLAYER_COUNT}`);
+    }
+
+    process.stdout.write('\n');
+    writeFileSync(OUTPUT, JSON.stringify(players, null, 1));
+    console.log(`wrote ${players.length} players to ${OUTPUT}`);
+}
+
+seed().catch((error) => {
+    console.error(`\n${error.message}`);
+    process.exit(1);
+});

--- a/loadtest/token.mjs
+++ b/loadtest/token.mjs
@@ -1,0 +1,73 @@
+// Mints the Supabase-shaped tokens the backend expects, signed with a keypair that
+// exists only for load testing.
+//
+// The alternative is to sign a hundred players in through the real Supabase project,
+// which rate-limits its own auth endpoints and would leave a hundred junk accounts in
+// the production user table. The backend does not care who issued the token as long as
+// it verifies against the JWKS it was pointed at: security.jwt.jwk-set-uri is a plain
+// environment variable (SUPABASE_JWKS_URI), so pointing a load-test backend at the
+// server in jwks-server.mjs is enough.
+//
+// The keypair is written to keys/ on first use and reused after that, so tokens minted
+// by seed.mjs stay valid for drive.mjs. It protects nothing — do not reuse it anywhere.
+
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createSign, randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const KEY_DIR = join(dirname(fileURLToPath(import.meta.url)), 'keys');
+const PRIVATE_KEY_PATH = join(KEY_DIR, 'private.pem');
+const KID = 'loadtest-key';
+
+/** Claims SupabaseClaimsValidator insists on, whatever signed the token. */
+const AUDIENCE = 'authenticated';
+const ROLE = 'authenticated';
+
+function base64url(input) {
+    return Buffer.from(input).toString('base64url');
+}
+
+function loadOrCreatePrivateKey() {
+    if (existsSync(PRIVATE_KEY_PATH)) {
+        return createPrivateKey(readFileSync(PRIVATE_KEY_PATH));
+    }
+
+    // RS256 rather than ES256 only because it is the duller of the two paths through
+    // node:crypto. SecurityConfig accepts either.
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    mkdirSync(KEY_DIR, { recursive: true });
+    writeFileSync(PRIVATE_KEY_PATH, privateKey.export({ type: 'pkcs8', format: 'pem' }));
+    return privateKey;
+}
+
+const privateKey = loadOrCreatePrivateKey();
+
+/** The document to serve at the address SUPABASE_JWKS_URI names. */
+export function jwks() {
+    const jwk = createPublicKey(privateKey).export({ format: 'jwk' });
+    return { keys: [{ ...jwk, kid: KID, alg: 'RS256', use: 'sig' }] };
+}
+
+/**
+ * A token that will pass verification for the given Supabase user id.
+ *
+ * No issuer claim: security.jwt.issuer is only enforced when it is set, and a load-test
+ * backend leaves SUPABASE_JWT_ISSUER empty.
+ */
+export function mintToken(supabaseUserId, ttlSeconds = 6 * 60 * 60) {
+    const now = Math.floor(Date.now() / 1000);
+    const header = { alg: 'RS256', typ: 'JWT', kid: KID };
+    const payload = {
+        sub: supabaseUserId,
+        aud: AUDIENCE,
+        role: ROLE,
+        iat: now,
+        exp: now + ttlSeconds,
+        session_id: randomUUID(),
+    };
+
+    const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+    const signature = createSign('RSA-SHA256').update(signingInput).sign(privateKey).toString('base64url');
+    return `${signingInput}.${signature}`;
+}


### PR DESCRIPTION
Steps 1 and 2 of the three we agreed: the alarm, then the load test. Step 3 was "look at the results and decide" — the results are below and they decide it fairly clearly.

## The alarm

`ServiceStoppedAlarm` watches `AWS/ECS` `LiveTaskCount` and emails through SNS. It turns out `LiveTaskCount` is published every minute **without** Container Insights, which is what makes this free — Container Insights is billed per metric and stays disabled on the cluster.

Five evaluation periods rather than one or two: with `MinimumHealthyPercent: 0` and containers that start in sequence behind each other's health checks, a normal deploy legitimately sits at zero tasks for two to four minutes. A deploy slower than five minutes has gone wrong anyway.

A stopped service publishes no datapoint at all rather than publishing a zero, so `TreatMissingData: breaching` is load-bearing — without it the alarm would sit at `INSUFFICIENT_DATA` through an entire outage.

**Still deploying manually.** The changeset was reviewed (three `Add`s, nothing touching the service, the task definition, the launch template or the ASG, so no downtime) but executing it needs your hands. The SNS confirmation email has to be clicked before anything is delivered.

## The load test

`loadtest/` drives 50 concurrent games over 100 WebSocket sessions and times two things from a single `GAME_ACTION`: how long until the acting player sees their own move, and how long until the **opponent** does. Both against one clock, which is why one process holds both sockets of a match rather than this being a k6 script.

Tokens are minted against a keypair that exists only for the test — `security.jwt.jwk-set-uri` is a plain environment variable, so a load-test backend can be pointed at it, and a hundred players never touch the real Supabase project.

### Clean database, 50 games / 100 sockets, 60s

```
                    count    mean     p50     p95     p99     max  (ms)
action               2647    42.4    15.7   190.6   510.0  1109.8
action→broadcast     2647    42.9    15.5   203.8   494.5  1093.6

3294 moves, 450 games, 0 rejected, 0 timed out, 0 errors
```

### Second run, same process, database now holding those 450 games

**OOM-killed at 768 MiB — the exact allocation the production task uses.** `OOMKilled=true`, exit 137, about forty seconds in. Memory had already finished the first run at 636 MiB and never came back down. Reproduced twice.

### Why

`NakamaMatchService.cleanupMatch` empties `matchMetadata`, `matchSubscriptions` and `activeSockets` for a finished match, and **nothing calls it**. `handleGameAction` logs the completion and returns. Every game ever played stays in those maps for the life of the process.

The two latency numbers being identical is its own finding: the per-session `convertToDto` in the broadcast loop is not what makes a move slow. The cost is upstream in `processMove`. And p99 being 32× p50 in the run that *succeeded* is the read amplification, not anything the machine ran out of.

## What this means for the plan

Goal 5 was going to ask "which resource gives out first, and is Prometheus how we find out". It gave out on memory, and the answer came from `docker stats` and a container exit code. Prometheus stays off the table.

Goal 4 now has a number attached and a way to tell whether fixing it worked.

## Caveats

Apple Silicon laptop against a local MongoDB, so these are not production latencies and shouldn't be quoted as such. They are a baseline for before-and-after on the same machine, which is the comparison that actually says something.