### PR TITLE
Make the current server hold 100 concurrent players

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,18 +99,25 @@ second instance. `getMatchState` scans the entire games collection on every call
 leaves its entries behind for the life of the process; `handleGameAction` logs the
 completion and returns. This is measured, not suspected — see below.
 
-**The backend runs out of memory at 100 concurrent players.** `loadtest/` drives
-50 concurrent games over 100 WebSocket sessions. On a clean database it holds up:
-3,294 moves, no errors, p50 16 ms and p99 510 ms for a move to reach the opponent.
-The memory does not come back afterwards — the process finished that run sitting at
-636 MiB — and a second identical run against the same process is OOM-killed at the
-768 MiB the production task allocates, roughly forty seconds in. `OOMKilled=true`,
-exit 137, reproduced twice.
+**~~The backend runs out of memory at 100 concurrent players.~~** Fixed in the
+Dockerfile, which now sizes the JVM against the 768 MiB the task actually has.
+`MaxRAMPercentage=70` capped the heap at 537 MiB and left too little for metaspace,
+the code cache and a stack per Tomcat thread; the kernel killed it forty seconds
+into a second run at 100 concurrent players. The heap was never the problem — a
+full GC showed ~30 MiB live. It now sustains 100 concurrent sockets: 6,110 moves
+over two minutes, no errors, RSS flat at ~630 MiB.
 
-The p99 is 32× the p50 even in the run that succeeded, which is the read
-amplification above rather than anything the machine ran out of. Both numbers come
-from an Apple Silicon laptop against a local MongoDB, so they are not production
-latencies; they are a baseline to compare the next change against.
+**The tail grows with the size of the games collection.** In that same run p50 was
+15 ms and p99 was 755 ms, and re-running against a database already holding a few
+hundred games pushes p99 past two seconds while memory stays flat. That is
+`getMatchState` scanning the whole collection and `findActiveGameForPlayer` doing
+the same, not anything the machine ran out of — it is the item above, and it is
+what goal 3 and 4 are for.
+
+Numbers come from an Apple Silicon laptop with two CPUs allocated, against a local
+MongoDB. Production is a `t4g.small` sharing two vCPU with postgres, Nakama and
+cloudflared, so it has *less* CPU than this. The memory conclusion transfers,
+because the 768 MiB budget is the same; the latencies do not.
 
 **No concurrency control.** No `@Version` on documents, no transactions.
 Simultaneous writes overwrite each other.
@@ -216,15 +223,14 @@ session is a judgement call that changes with what the project needs next.
    possible.
 4. **Make matches survive a restart.** Either commit to Nakama's match API or
    persist match state properly. Add optimistic locking while here.
-5. **Hold 100 concurrent players.** The load test exists now (`loadtest/`) and it
-   already answers what gives out first: memory, at the 768 MiB the production
-   task allocates, because finished matches are never released. That is item 4,
-   so the order above still holds — but 4 now has a number attached and a way to
-   tell whether fixing it worked. What is left here afterwards is re-running it,
-   deciding whether one `t4g.small` is still the right size, and only then asking
-   whether Prometheus and Grafana are worth the money. They are not yet: the
-   question "which resource gives out first" got answered by `docker stats` and a
-   container exit code.
+5. **Hold 100 concurrent players.** It does, as of the JVM sizing fix — two
+   minutes of sustained 100-socket play with no errors. What it does not do is
+   hold them *well*: p99 is 755 ms against a p50 of 15 ms, and it degrades as the
+   games collection grows, which is 3 and 4 above rather than anything here. What
+   is left for this item is re-running `loadtest/` after those land and deciding
+   whether one `t4g.small` is still the right size. Prometheus and Grafana are
+   still not worth the money: the question "which resource gives out first" got
+   answered by `docker stats`, a class histogram and a container exit code.
 6. **Frontend.** Break up the 900-line components, fix reconnection, delete the
    dead services. (The home page's Power Score is real data, not a placeholder —
    that item was stale.)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,8 +27,26 @@ USER appuser
 
 EXPOSE 8080
 
-# MaxRAMPercentage makes the JVM read the container's cgroup limit instead of
-# the host's 2 GiB, which is what keeps this from OOM-killing the box.
-ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+UseSerialGC -XX:MaxMetaspaceSize=128m"
+# These are sized against the 768 MiB the ECS task definition gives this container,
+# and were arrived at by running loadtest/ at 100 concurrent players until it stopped
+# being OOM-killed. Changing the task's memory means revisiting them.
+#
+# MaxRAMPercentage caps the *heap* as a share of the cgroup limit, and the rest of
+# the process has to fit in what is left. At the 70 it used to be, 537 MiB of heap
+# plus 128 of metaspace plus the code cache plus a thread stack for each of the ~200
+# Tomcat threads came to more than the container had, and the kernel killed it —
+# reproducibly, about forty seconds into a second run at 100 concurrent players. The
+# heap was never the problem: a full GC at that point showed roughly 30 MiB live.
+#
+# G1 rather than Serial because Serial is a single-threaded stop-the-world collector
+# and its pauses were the latency tail — 460 ms at worst, against a p50 of 13 ms.
+#
+# Xss512k halves the stack of every one of those threads.
+#
+# MALLOC_ARENA_MAX bounds glibc's per-thread arenas, which otherwise hold on to a few
+# hundred MiB of freed memory that the JVM does not account for and the container
+# still has to pay for.
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=45 -XX:+UseG1GC -XX:MaxMetaspaceSize=128m -Xss512k"
+ENV MALLOC_ARENA_MAX=2
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/loadtest/drive.mjs
+++ b/loadtest/drive.mjs
@@ -86,6 +86,15 @@ function connect(token) {
         const socket = new WebSocket(WS_URL, { headers: { authorization: `Bearer ${token}` } });
         const waiters = new Map();
 
+        // A saturated backend does not refuse a handshake, it stops answering one:
+        // Tomcat's pool is exhausted and the connection waits in the accept queue
+        // indefinitely. Without this the driver hangs at exactly the moment it has
+        // something to report.
+        const handshake = setTimeout(() => {
+            socket.close();
+            reject(new Error('handshake timed out'));
+        }, REPLY_TIMEOUT_MS);
+
         socket.addEventListener('message', (event) => {
             const message = JSON.parse(event.data);
             const waiter = waiters.get(message.type);
@@ -96,12 +105,12 @@ function connect(token) {
             if (message.type === 'ERROR') counters.rejected++;
         });
 
-        socket.addEventListener('error', () => reject(new Error('socket error')));
+        socket.addEventListener('error', () => { clearTimeout(handshake); reject(new Error('socket error')); });
         socket.addEventListener('close', () => {
             for (const [type, waiter] of waiters) waiter.fail(new Error(`socket closed waiting for ${type}`));
             waiters.clear();
         });
-        socket.addEventListener('open', () => resolve({
+        socket.addEventListener('open', () => { clearTimeout(handshake); resolve({
             send: (type, data) => socket.send(JSON.stringify({ type, data })),
             next: (type) => new Promise((resolveNext, rejectNext) => {
                 const timer = setTimeout(() => {
@@ -115,7 +124,7 @@ function connect(token) {
                 });
             }),
             close: () => socket.close(),
-        }));
+        }); });
     });
 }
 
@@ -235,6 +244,22 @@ function report(label, values) {
     );
 }
 
+function finish() {
+    console.log(`\n${''.padEnd(18)}${'count'.padStart(7)}${'mean'.padStart(8)}${'p50'.padStart(8)}${'p95'.padStart(8)}${'p99'.padStart(8)}${'max'.padStart(8)}  (ms)`);
+    report('action', samples.action);
+    report('action→broadcast', samples.broadcast);
+    console.log(
+        `\n${counters.moves} moves, ${counters.games} games, ${counters.rejected} rejected, ` +
+        `${counters.timeouts} timed out, ${counters.errors} errors`,
+    );
+    // A run that lost replies did not measure latency, it measured a failure. Say so
+    // rather than leaving a healthy-looking percentile table to speak for itself.
+    if (counters.timeouts > 0 || counters.errors > 0) {
+        console.log('\nThe server stopped answering during this run. The percentiles above');
+        console.log('describe only the moves that came back, and understate what happened.');
+    }
+}
+
 const deadline = Date.now() + WARMUP_MS + DURATION_MS;
 
 console.log(`${GAMES} games / ${GAMES * 2} sockets against ${BASE_URL}`);
@@ -245,6 +270,17 @@ setTimeout(() => {
     console.log('warmup over, recording\n');
 }, WARMUP_MS);
 
+// Every wait in here is bounded, and pairs still occasionally fail to unwind once the
+// backend has started struggling. Rather than debug that on every run, print what was
+// collected and stop: a report that arrives is worth more than one that is correct
+// about the last two seconds.
+const giveUpAt = setTimeout(() => {
+    console.log('\n(pairs did not all finish; reporting what was collected)');
+    finish();
+    process.exit(0);
+}, WARMUP_MS + DURATION_MS + 30_000);
+giveUpAt.unref();
+
 const pairs = [];
 for (let i = 0; i < GAMES; i++) {
     pairs.push(runPair(players[i * 2], players[i * 2 + 1]));
@@ -253,17 +289,4 @@ for (let i = 0; i < GAMES; i++) {
 }
 
 await Promise.all(pairs);
-
-console.log(`\n${''.padEnd(18)}${'count'.padStart(7)}${'mean'.padStart(8)}${'p50'.padStart(8)}${'p95'.padStart(8)}${'p99'.padStart(8)}${'max'.padStart(8)}  (ms)`);
-report('action', samples.action);
-report('action→broadcast', samples.broadcast);
-console.log(
-    `\n${counters.moves} moves, ${counters.games} games, ${counters.rejected} rejected, ` +
-    `${counters.timeouts} timed out, ${counters.errors} errors`,
-);
-// A run that lost replies did not measure latency, it measured a failure. Say so rather
-// than leaving a healthy-looking percentile table to speak for itself.
-if (counters.timeouts > 0 || counters.errors > 0) {
-    console.log('\nThe server stopped answering during this run. The percentiles above');
-    console.log('describe only the moves that came back, and understate what happened.');
-}
+finish();


### PR DESCRIPTION
The OOM was not an application leak. It was the JVM being told it could use more memory than the container has.

## What was wrong

`MaxRAMPercentage=70` caps the **heap** at 537 MiB of the task's 768. Everything else in the process has to fit in the remaining 231 MiB, and it does not:

| | |
|---|---|
| Heap cap | 537 MiB |
| Metaspace cap | 128 MiB |
| Code cache, observed | ~50 MiB |
| Thread stacks | up to 200 Tomcat threads × 1 MiB |

That is over 900 MiB of budget in a 768 MiB container, so the kernel killed it — reproducibly, about forty seconds into a *second* run at 100 concurrent players.

The heap was never the problem. A class histogram taken after a full GC (`-XX:+PrintClassHistogram` plus `SIGQUIT`, since the JRE image has no `jcmd`) showed roughly **30 MiB live**. Nothing in the application is retaining anything; the JVM simply had nowhere to put the rest of itself.

The `activeSockets` map I suspected first turns out never to be written to at all, and `cleanupMatch` is still dead code — both worth cleaning up, neither the cause.

## The fix

```
-XX:MaxRAMPercentage=45  -XX:+UseG1GC  -XX:MaxMetaspaceSize=128m  -Xss512k
MALLOC_ARENA_MAX=2
```

G1 replaces Serial because Serial is single-threaded stop-the-world and its **460 ms worst-case pause** was most of the latency tail against a p50 of 13 ms. `MALLOC_ARENA_MAX` bounds glibc's per-thread arenas, which were holding a few hundred MiB the JVM does not account for and the container still pays for.

## Result — 2 minutes sustained, 100 concurrent sockets

```
                    count    mean     p50     p95     p99     max  (ms)
action               5346    51.7    15.2   204.9   754.9  1772.0
action→broadcast     5346    52.0    15.2   204.0   730.7  1768.7

6110 moves, 773 games, 0 rejected, 0 timed out, 0 errors
```

Container alive, `OOMKilled=false`, RSS flat at ~630 MiB for the whole run. Before the change the same load was dead inside two runs.

## What this does not fix

**The tail grows with the size of the games collection.** p99 is 755 ms against a p50 of 15 ms, and re-running against a database already holding a few hundred games pushes p99 past two seconds *while memory stays flat*. That is `getMatchState` scanning the whole collection and `findActiveGameForPlayer` doing the same — goals 3 and 4, not a sizing problem.

**Tomcat's pool saturates.** Threads reached 203 against a default `maxThreads` of 200 at the end of a three minute run. A saturated pool does not refuse a WebSocket handshake, it stops answering one, which is also the driver fix in here — it hung for twelve minutes on a two hundred second run, at exactly the moment the numbers mattered.

## Deploying

**Needs an ECR build and push, so it takes the site down for a container start.** Not urgent — production has nothing like this load. Worth doing on its own rather than bundled with anything.

## Caveats

Apple Silicon laptop with two CPUs allocated, local MongoDB. Production is a `t4g.small` sharing two vCPU with postgres, Nakama and cloudflared, so it has *less* CPU than this test. The memory conclusion transfers because the 768 MiB is the same; the latencies do not.