### PR TITLE
Cut p95 from 205ms to 52ms without spending anything

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,12 +107,23 @@ into a second run at 100 concurrent players. The heap was never the problem — 
 full GC showed ~30 MiB live. It now sustains 100 concurrent sockets: 6,110 moves
 over two minutes, no errors, RSS flat at ~630 MiB.
 
-**The tail grows with the size of the games collection.** In that same run p50 was
-15 ms and p99 was 755 ms, and re-running against a database already holding a few
-hundred games pushes p99 past two seconds while memory stays flat. That is
-`getMatchState` scanning the whole collection and `findActiveGameForPlayer` doing
-the same, not anything the machine ran out of — it is the item above, and it is
-what goal 3 and 4 are for.
+**~~The tail grows with the size of the games collection.~~** Was p99 755 ms rising
+past two seconds once a few hundred games had accumulated. The collections carried
+no indexes at all — `spring.data.mongodb.auto-index-creation` defaults to false, so
+the `@Indexed` annotations built nothing — and `getMatchState` read every game into
+the JVM to find one. `MongoIndexes` now creates what the hot queries need, that
+lookup is an equality query, and a move no longer re-reads players once per
+connected socket. p95 205 ms → 52 ms, p99 755 ms → 91 ms, max 1.8 s → 196 ms, and a
+second run against 850 accumulated games only reaches p95 60 ms.
+
+**Player's unique indexes do not exist.** `Player` declares `@Indexed(unique = true)`
+on name, email, `nakamaUserId` and `supabaseUserId`, and none of them is built,
+because auto-index-creation is off. Nothing at the database level stops a second
+account on an existing email — which is exactly what the `@Disabled` test in
+`SupabaseEmailVerificationIntegrationTest` says. Turning auto-index-creation on is
+*not* the fix on its own: the indexes are not sparse and those last two fields are
+nullable, so a second document with a null would fail the build and stop the
+application starting. It needs a duplicate audit against production first.
 
 Numbers come from an Apple Silicon laptop with two CPUs allocated, against a local
 MongoDB. Production is a `t4g.small` sharing two vCPU with postgres, Nakama and
@@ -223,13 +234,12 @@ session is a judgement call that changes with what the project needs next.
    possible.
 4. **Make matches survive a restart.** Either commit to Nakama's match API or
    persist match state properly. Add optimistic locking while here.
-5. **Hold 100 concurrent players.** It does, as of the JVM sizing fix — two
-   minutes of sustained 100-socket play with no errors. What it does not do is
-   hold them *well*: p99 is 755 ms against a p50 of 15 ms, and it degrades as the
-   games collection grows, which is 3 and 4 above rather than anything here. What
-   is left for this item is re-running `loadtest/` after those land and deciding
-   whether one `t4g.small` is still the right size. Prometheus and Grafana are
-   still not worth the money: the question "which resource gives out first" got
+5. **Hold 100 concurrent players.** It does, and now holds them well: p50 11 ms,
+   p95 52 ms, p99 91 ms over two minutes of sustained 100-socket play, no errors,
+   memory flat. What is left is a decision rather than work — a move still costs
+   about ten database round trips, and the floor while the database is on the hot
+   path is one Atlas round trip times that. Taking it off the hot path is item 4.
+   Prometheus and Grafana are still not worth the money: every question so far got
    answered by `docker stats`, a class histogram and a container exit code.
 6. **Frontend.** Break up the 900-line components, fix reconnection, delete the
    dead services. (The home page's Power Score is real data, not a placeholder —

--- a/backend/src/main/java/com/cardgame/config/MongoIndexes.java
+++ b/backend/src/main/java/com/cardgame/config/MongoIndexes.java
@@ -1,0 +1,75 @@
+package com.cardgame.config;
+
+import com.cardgame.model.Deck;
+import com.cardgame.model.GameModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.stereotype.Component;
+
+/**
+ * Creates the indexes the hot queries need.
+ *
+ * <p>Until this existed the collections carried nothing but {@code _id_}, so every lookup
+ * by player or by match read the whole collection. That is what made latency grow with
+ * the number of games ever played rather than with the number being played now: a load
+ * test that was comfortable on an empty database pushed p99 past two seconds once a few
+ * hundred games had accumulated.
+ *
+ * <p>The indexes are declared here rather than with {@code @Indexed} because
+ * {@code spring.data.mongodb.auto-index-creation} defaults to false in Boot 3, and
+ * turning it on would also try to build the unique indexes that {@link
+ * com.cardgame.model.Player} asks for. Those are a separate problem and a riskier one:
+ * they are not sparse, several of the fields are nullable, and a second document with a
+ * null would fail the build and take the application down at startup. Note that this
+ * means the uniqueness Player declares is not enforced by the database today — which is
+ * why a second account can be created on an existing email.
+ *
+ * <p>Creation is idempotent; MongoDB ignores an index that already exists with the same
+ * definition. It is deliberately not fatal: an index that cannot be built is a slow
+ * application, not a broken one, and refusing to start would be the worse failure.
+ */
+@Component
+public class MongoIndexes implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(MongoIndexes.class);
+
+    private final MongoTemplate mongoTemplate;
+
+    public MongoIndexes(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        // NakamaMatchService.getMatchState used to read every game in the collection and
+        // filter in the JVM. It is reached from isPlayerInMatch, so that ran on every
+        // join.
+        ensure(GameModel.class, new Index().on("nakamaMatchId", Sort.Direction.ASC).named("game_nakama_match"));
+
+        // Serves both findByPlayerIdsContainingAndGameStateIn and the OrderBy variant of
+        // it. playerIds is an array, which makes this multikey — allowed, because it is
+        // the only array in the key.
+        ensure(GameModel.class, new Index()
+                .on("playerIds", Sort.Direction.ASC)
+                .on("gameState", Sort.Direction.ASC)
+                .on("updatedAt", Sort.Direction.DESC)
+                .named("game_player_state_recent"));
+
+        ensure(Deck.class, new Index().on("ownerId", Sort.Direction.ASC).named("deck_owner"));
+    }
+
+    private void ensure(Class<?> collection, Index index) {
+        try {
+            String name = mongoTemplate.indexOps(collection).ensureIndex(index);
+            logger.info("Index {} ready on {}", name, mongoTemplate.getCollectionName(collection));
+        } catch (RuntimeException e) {
+            logger.warn("Could not create an index on {}: {}. Queries will still work, slowly.",
+                    mongoTemplate.getCollectionName(collection), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/cardgame/repository/GameRepository.java
+++ b/backend/src/main/java/com/cardgame/repository/GameRepository.java
@@ -27,6 +27,16 @@ public interface GameRepository extends MongoRepository<GameModel, String> {
         String playerId, List<GameState> states);
 
     /**
+     * Find the game backing a Nakama match.
+     *
+     * <p>The stored value is {@code "nakama_" + matchId}; see NakamaMatchService. This
+     * replaced a scan of the whole collection that matched on {@code contains(matchId)},
+     * which was both slower and looser — one match id being a substring of another would
+     * have returned the wrong game.
+     */
+    Optional<GameModel> findByNakamaMatchId(String nakamaMatchId);
+
+    /**
      * Delete every game this player took part in, whatever state it is in.
      *
      * <p>A game names its participants and nothing else names the game, so a game whose

--- a/backend/src/main/java/com/cardgame/service/GameService.java
+++ b/backend/src/main/java/com/cardgame/service/GameService.java
@@ -79,14 +79,38 @@ public class GameService {
     }
     
     public GameDto convertToDto(GameModel gameModel, String forPlayerId) {
-        Player currentPlayer = playerService.getPlayer(forPlayerId);
+        return convertToDto(gameModel, forPlayerId, loadPlayers(gameModel));
+    }
+
+    /**
+     * Reads every player named by the game, once.
+     *
+     * <p>A move is broadcast to each session in the match, and each of those needs a view
+     * of the game built for its own player. Converting per session re-read every player
+     * per conversion, so a two-player match cost six reads to send two messages. Loading
+     * them here and handing the same map to each conversion makes it two.
+     */
+    public Map<String, Player> loadPlayers(GameModel gameModel) {
+        Map<String, Player> players = new HashMap<>();
+        for (String playerId : gameModel.getPlayerIds()) {
+            players.put(playerId, playerService.getPlayer(playerId));
+        }
+        return players;
+    }
+
+    public GameDto convertToDto(GameModel gameModel, String forPlayerId, Map<String, Player> players) {
+        // forPlayerId is normally one of the game's players and already loaded; a
+        // spectator or an admin looking at somebody else's game is the exception.
+        Player currentPlayer = players.containsKey(forPlayerId)
+                ? players.get(forPlayerId)
+                : playerService.getPlayer(forPlayerId);
 
         // Build card ownership map, collect all placed cards, and player names
         Map<String, String> cardOwnership = new HashMap<>();
         Map<String, CardDto> placedCards = new HashMap<>();
         Map<String, String> playerNames = new HashMap<>();
         for (String playerId : gameModel.getPlayerIds()) {
-            Player player = playerService.getPlayer(playerId);
+            Player player = players.get(playerId);
             // Add player name
             playerNames.put(playerId, player.getName());
             
@@ -302,6 +326,19 @@ public class GameService {
      * Process a player's move
      */
     public GameDto processMove(String gameId, PlayerAction action) {
+        return convertToDto(applyMove(gameId, action));
+    }
+
+    /**
+     * Applies a move and returns the saved game, without converting it.
+     *
+     * <p>Split out of {@link #processMove} for the WebSocket handler, which broadcasts a
+     * separate view of the result to each session and so has no use for the one
+     * conversion processMove would do — it used to throw that away and then re-read the
+     * game it had just saved. Between them those were four database round trips per move
+     * that nothing looked at.
+     */
+    public GameModel applyMove(String gameId, PlayerAction action) {
         GameModel gameModel = gameRepository.findById(gameId)
                 .orElseThrow(() -> new GameNotFoundException("Game not found: " + gameId));
 
@@ -327,8 +364,7 @@ public class GameService {
             // For win requests, we switch to the next player and return
             switchToNextPlayer(gameModel);
             gameModel.setUpdatedAt(Instant.now());
-            gameModel = gameRepository.save(gameModel);
-            return convertToDto(gameModel);
+            return gameRepository.save(gameModel);
         }
 
         // Check if game is over (for regular moves)
@@ -342,12 +378,10 @@ public class GameService {
         gameModel.setUpdatedAt(Instant.now());
 
         // Save and return updated game state
-        gameModel = gameRepository.save(gameModel);
-
-        return convertToDto(gameModel);
+        return gameRepository.save(gameModel);
     }
 
-    private GameDto handleWinRequestResponse(GameModel gameModel, PlayerAction action) {
+    private GameModel handleWinRequestResponse(GameModel gameModel, PlayerAction action) {
         String respondingPlayerId = action.getPlayerId();
 
         // Validate that there's a pending win request
@@ -379,9 +413,7 @@ public class GameService {
         gameModel.setUpdatedAt(Instant.now());
 
         // Save and return updated game state
-        gameModel = gameRepository.save(gameModel);
-
-        return convertToDto(gameModel);
+        return gameRepository.save(gameModel);
     }
 
     private boolean isGameOver(GameModel gameModel) {

--- a/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
+++ b/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
@@ -48,6 +48,9 @@ public class NakamaMatchService {
     @Lazy  // Use @Lazy to avoid circular dependency
     private GameWebSocketHandler gameWebSocketHandler;
     
+    /** What a game's nakamaMatchId is prefixed with. Written once, read by getMatchState. */
+    private static final String NAKAMA_MATCH_ID_PREFIX = "nakama_";
+
     // Store active socket connections
     private final Map<String, SocketClient> activeSockets = new ConcurrentHashMap<>();
     
@@ -188,7 +191,7 @@ public class NakamaMatchService {
                 
                 // Set online mode fields
                 game.setGameMode(GameMode.ONLINE);
-                game.setNakamaMatchId("nakama_" + matchId);
+                game.setNakamaMatchId(NAKAMA_MATCH_ID_PREFIX + matchId);
                 
                 // Initialize player connections
                 Map<String, ConnectionStatus> connections = new HashMap<>();
@@ -325,12 +328,11 @@ public class NakamaMatchService {
      * @return The current game state
      */
     public GameModel getMatchState(String matchId) {
-        // Find game by Nakama match ID
-        Optional<GameModel> game = gameRepository.findAll().stream()
-            .filter(g -> g.getNakamaMatchId() != null && g.getNakamaMatchId().contains(matchId))
-            .findFirst();
-            
-        return game.orElseThrow(() -> new IllegalArgumentException("Match not found"));
+        // This used to read every game in the collection into the JVM and filter there,
+        // and isPlayerInMatch calls it on every join, so the cost grew with the number of
+        // games ever played. The stored value is exactly "nakama_" + matchId.
+        return gameRepository.findByNakamaMatchId(NAKAMA_MATCH_ID_PREFIX + matchId)
+            .orElseThrow(() -> new IllegalArgumentException("Match not found"));
     }
     
     /**

--- a/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
+++ b/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
@@ -294,20 +294,24 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                 return;
             }
             
-            // Process the move
-            gameService.processMove(metadata.gameId, playerAction);
-            
-            // Get the updated game model for checking end state
-            var updatedGame = gameService.getGameModel(metadata.gameId);
-            
+            // Process the move. applyMove rather than processMove because each session
+            // below needs a view built for its own player, so the one conversion
+            // processMove does would be thrown away — along with the re-read of the game
+            // it had just saved.
+            var updatedGame = gameService.applyMove(metadata.gameId, playerAction);
+
             // Broadcast updated game state to all players in the match
             Set<WebSocketSession> sessions = matchSessions.get(info.matchId);
             if (sessions != null) {
+                // Read each player once for the whole broadcast instead of once per
+                // conversion. This is the hot path: it runs on every move, for every
+                // connected socket.
+                var players = gameService.loadPlayers(updatedGame);
                 for (WebSocketSession s : sessions) {
                     SessionInfo sInfo = sessionInfoMap.get(s.getId());
                     if (sInfo != null) {
                         // Get game DTO specific to each player
-                        var playerGameDto = gameService.convertToDto(updatedGame, sInfo.playerId);
+                        var playerGameDto = gameService.convertToDto(updatedGame, sInfo.playerId, players);
                         sendMessage(s, new WebSocketMessage(
                             MessageType.GAME_STATE_UPDATE,
                             playerGameDto


### PR DESCRIPTION
Three changes, all free, measured on the same `loadtest/` run as the baseline.

## Result — 2 minutes, 100 concurrent sockets, identical conditions

| | before | after |
|---|---|---|
| p50 | 15.2 ms | **11.3 ms** |
| **p95** | **204.9 ms** | **51.8 ms** |
| p99 | 754.9 ms | **91.1 ms** |
| max | 1772 ms | **196 ms** |
| moves | 6110 | 6562 |
| RSS | 627 MiB | 568 MiB |

And the case that used to be fatal — a **second** run against the 850 games the first one left behind — now reaches p95 60 ms, p99 123 ms, no errors. Before the JVM fix that was an OOM kill; after it, p99 past two seconds.

## What was wrong

**No indexes existed at all.** Not one collection had anything but `_id_`. `spring.data.mongodb.auto-index-creation` defaults to false in Boot 3, so the `@Indexed` annotations on `Player` were building nothing. Every `findByPlayerIdsContaining…` was a collection scan.

**`getMatchState` read the entire games collection into the JVM** and filtered there, and `isPlayerInMatch` calls it on every join. That was both the tail and a good part of the memory growth. The stored value is exactly `"nakama_" + matchId`, so an equality query serves it — and is stricter than the `contains()` it replaces, which would match the wrong game whenever one match id contained another.

**A move re-read the same rows several times.** Broadcasting converted the game once per session and each conversion re-read every player, so a two-player match spent six reads to send two messages. On top of that `processMove` built a conversion the WebSocket handler had no use for, and the handler then re-read the game that had just been saved.

Roughly 18 round trips per move down to about 10.

## A separate finding, worth its own work

**None of `Player`'s unique indexes exist either.** Same cause. Nothing at the database level stops a second account on an existing email — which is exactly what the `@Disabled` test in `SupabaseEmailVerificationIntegrationTest` has been saying.

Turning on auto-index-creation is **not** the fix by itself: those indexes are not sparse and `nakamaUserId` / `supabaseUserId` are nullable, so a second document with a null fails the index build and stops the application starting. It needs a duplicate audit against production first. Deliberately not in this PR.

## Testing

133 tests, 0 failures, 2 skipped (the pre-existing `@Disabled` pair).

## Deploying

Needs an ECR build and push like the last one. The index creation runs at startup, is idempotent, and is deliberately non-fatal — an index that cannot be built is a slow application, not a broken one.