### PR TITLE
Let players back in when Nakama has lost their account

### DIFF
--- a/backend/src/main/java/com/cardgame/controller/UnifiedAuthController.java
+++ b/backend/src/main/java/com/cardgame/controller/UnifiedAuthController.java
@@ -167,13 +167,29 @@ public class UnifiedAuthController {
             
             // Player has Nakama account, create a new session
             Session nakamaSession = authenticateWithNakama(player);
+
             if (nakamaSession == null) {
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ImmutableAuthDto.builder()
-                        .isSuccess(false)
-                        .message("Failed to create game session")
-                        .build());
+                // A stored id can outlive the account it names. Nakama's Postgres was
+                // replaced when it moved onto a volume of its own, so every player kept
+                // a nakamaUserId pointing at an account that no longer exists — and the
+                // branch above only creates one when the id is null, which theirs is
+                // not. Without this they can never sign in again.
+                logger.warn("Nakama has no account for player {}; the stored id {} is stale. Recreating.",
+                        player.getId(), player.getNakamaUserId());
+                nakamaSession = createNakamaAccount(player, email);
+
+                if (nakamaSession == null) {
+                    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ImmutableAuthDto.builder()
+                            .isSuccess(false)
+                            .message("Failed to create game session")
+                            .build());
+                }
+
+                player.setNakamaUserId(nakamaSession.getUserId());
+                playerService.savePlayer(player);
+                logger.info("Relinked player {} to Nakama account {}", player.getId(), nakamaSession.getUserId());
             }
-            
+
             playerLoginCounter.increment();
             return ResponseEntity.ok(buildAuthResponse(player, nakamaSession));
             


### PR DESCRIPTION
**Every account created before the Nakama-Postgres volume migration has been locked out since 2026-08-16 04:37 PDT.** Found while checking whether today's deploys had broken login — they had not; the first occurrence predates them by sixteen hours.

## What happens

```
NakamaAuthService  : Email authentication failed: NOT_FOUND: User account not found.
UnifiedAuthController: Failed to authenticate with Nakama for player: 6a8237c7…
```

MongoDB still holds the player and their `nakamaUserId`. Nakama's Postgres does not hold the account that id names — it was replaced when Nakama's database moved onto a volume of its own, and came up empty.

`loginWithSupabase` then has no way out:

```java
if (player.getNakamaUserId() == null) { create }   // skipped — the id is not null
Session s = authenticateWithNakama(player);         // NOT_FOUND
if (s == null) return 500;                          // dead end
```

The account can never be recreated, because recreation is gated on the id being null and it never will be again.

## The fix

Fall back to `createNakamaAccount` when authentication fails, and write the new id back. That method already does the right thing — it tries to authenticate and creates on failure — it was simply unreachable from this path.

An affected account repairs itself on the next sign-in. No migration, no manual intervention, nothing to run against the database.

## Not fixed here

`syncVerifiedUser` has the same `id == null` gate, but it returns a response without a Nakama session, so a stale id does not fail it — it just does not repair it either. Login repairs it, which is enough.

The deeper issue is that Nakama's Postgres holds account state with no backup of its own (only MongoDB is backed up nightly), so losing that volume loses every game account again. Worth its own work.

## Testing

133 tests, 0 failures, 2 skipped (the pre-existing `@Disabled` pair). The fix itself is not covered — exercising it needs a Nakama that will answer NOT_FOUND, which the suite has no way to arrange today.