### PR TITLE
Write down that Nakama's Postgres is the only copy of every game account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,17 @@ one game at a time, `convertToDto` re-reads every player on every state
 conversion (and that runs once per connected socket per move), and finishing a
 game has to "restore" the player's original deck — a crash mid-game loses it.
 
+**Nakama's Postgres holds account state and has no backup.** The nightly `mongodump`
+to S3 covers MongoDB and nothing else, but a player's *game* account lives in
+Nakama's Postgres on the data volume. Losing that volume loses every game account
+while MongoDB still holds a `nakamaUserId` for each of them — which is not
+hypothetical: it happened when Nakama's Postgres moved onto its own volume and came
+up empty, and it locked every account created before that deploy out of the game
+from 2026-08-16 04:37 PDT until the login path learned to recreate a missing
+account. That recovery is in place now, so the failure is survivable, but the
+backup gap is not fixed: the volume is still the only copy. `pg_dump` alongside the
+existing `mongodump` job is the obvious answer.
+
 **Online matches are in-memory, and they are never released.** `NakamaMatchService`
 keeps matches in a `ConcurrentHashMap` and never uses Nakama's match API despite the
 dependency. A restart drops every active match, and the design cannot survive a


### PR DESCRIPTION
Found while diagnosing the lockout fixed in #40.

The nightly `mongodump` to S3 covers MongoDB and nothing else, but a player's *game* account lives in Nakama's Postgres on the data volume. Losing that volume loses every game account while MongoDB keeps a `nakamaUserId` for each of them.

That is not hypothetical — it is exactly what happened when Nakama's Postgres moved onto its own volume and came up empty, and it locked every account created before that deploy out of the game from 2026-08-16 04:37 PDT until #40 shipped.

#40 makes the failure survivable: login recreates a missing account and writes the new id back. It does not close the backup gap. The volume is still the only copy, and `pg_dump` alongside the existing `mongodump` job is the obvious answer.

Documentation only.