### PR TITLE
Move game state onto the game document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,9 +185,8 @@ should name is `https://api.handoffate.org`.
 security tests are plain unit tests, but everything else is still
 `@SpringBootTest` against a live MongoDB — there is no Testcontainers. Each
 class uses a database of its own; they used to share one and delete each other's
-data. Two tests are `@Disabled`, each with the reason on it: adjacency
-validation wrongly permits some moves, and player creation does not reject a
-second account on an existing email.
+data. One test is `@Disabled`, with the reason on it: player creation does not
+reject a second account on an existing email.
 
 **Frontend reconnect is dead code.** `connect()` sets `isReconnecting = true`
 on entry and `handleReconnect()` returns early when it is true, so a dropped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,21 @@ Not currently reachable — the security group has no inbound rules and Nakama's
 is not published — but exposing Nakama for any reason turns it into account
 takeover.
 
-**Game state lives on the Player document.** Hand, placed cards, and the active
-deck are fields on `Player`, not on the game. A player can therefore only be in
-one game at a time, `convertToDto` re-reads every player on every state
-conversion (and that runs once per connected socket per move), and finishing a
-game has to "restore" the player's original deck — a crash mid-game loses it.
+**~~Game state lives on the Player document.~~** Moved onto `GameModel`, keyed by
+player id: `hands`, `placed_cards` and `player_names`. A player can be in several games
+at once, `convertToDto` reads nothing, and there is no deck to restore because a game
+never borrows one. The temporary deck was deleted rather than moved — a deck is five
+cards and a hand is five cards, so the copy it made was empty from the moment it
+existed.
+
+Measured on the same harness, same machine, before and after, by profiling every
+operation MongoDB saw: **28.4 database operations per move → 6.1**, of which player
+reads were **22.5 → 1.8**. The old number was dominated by `hasValidMoves`, which asked
+the validator about every empty square and had the validator read the player each time.
+p50 11 ms → 6, p95 52 ms → 20-30, p99 91 ms → 32-50 over two runs of 100 concurrent
+sockets; RSS 630 MiB → 520. `action` and `action→broadcast` in the load test are now the
+same number to a tenth of a millisecond, which is the read amplification gone: the gap
+between them used to be the cost of rebuilding the view once per connected socket.
 
 **Nakama's Postgres holds account state and has no backup.** The nightly `mongodump`
 to S3 covers MongoDB and nothing else, but a player's *game* account lives in
@@ -238,24 +248,23 @@ session is a judgement call that changes with what the project needs next.
    is unit-testable game logic and Testcontainers, so the suite stops needing a
    MongoDB somebody remembered to start. This is also what makes the later
    refactors safe.
-3. **Move game state onto the game.** (Backups exist now, so this is no longer a
-   change made without a net.) The single change that unblocks
-   concurrent games per player, kills the N+1 reads, and makes crash recovery
-   possible. It also turns a move into one document write, which is what makes
-   the next item small: MongoDB is atomic per document on its own, so what is
-   left afterwards is `@Version` for the read-modify-write race, not transactions.
-   **This is the next session's work**; the working checklist is in the notes
+3. ~~**Move game state onto the game.**~~ Done — see Known problems above for what
+   it measured. A move is now one read and one write of one document, which is
+   what makes the next item small: MongoDB is atomic per document on its own, so
+   what is left is `@Version` for the read-modify-write race, not transactions.
+   **That is the next session's work**; the working checklist is in the notes
    outside the repository.
 4. **Make matches survive a restart,** with optimistic locking. Either commit to
    Nakama's match API or persist match state properly.
 
-   Afterwards a projection becomes worth building, and only afterwards: the read
-   side needs one clean thing to project from, and today the write model is split
-   across `Player` documents. Measured 2026-08-17: **only `currentPlayerHand`
-   varies per player** in `convertToDto` — board, ownership, placed cards, names,
-   column scores and state are identical for everyone, and that identical part is
-   rebuilt once per connected socket on every move. Building it once per move
-   instead is worth doing on its own, before any of the architecture.
+   Afterwards a projection becomes worth building, and only afterwards. The read
+   side has one clean thing to project from now that the write model is a single
+   document. **Only `currentPlayerHand` varies per player** in `convertToDto` —
+   board, ownership, placed cards, names, column scores and state are identical
+   for everyone, and that identical part is still rebuilt once per connected
+   socket on every move. Building it once per move instead is worth doing on its
+   own, before any of the architecture, though it is now CPU rather than database
+   round trips: the conversion no longer reads anything.
 
    Note that the broadcast has to go out immediately after the move, so such a
    projection would be updated synchronously. That is a cached view rather than

--- a/backend/src/main/java/com/cardgame/controller/admin/AdminController.java
+++ b/backend/src/main/java/com/cardgame/controller/admin/AdminController.java
@@ -144,16 +144,12 @@ public class AdminController {
             result.put("playerId", player.getId());
             result.put("playerName", player.getName());
             result.put("hasCurrentDeck", player.getCurrentDeck() != null);
-            result.put("hasOriginalDeck", player.getOriginalDeck() != null);
-            
+
             if (player.getCurrentDeck() != null) {
                 result.put("currentDeckId", player.getCurrentDeck().getId());
+                result.put("currentDeckCardCount", player.getCurrentDeck().getCards().size());
             }
-            if (player.getOriginalDeck() != null) {
-                result.put("originalDeckId", player.getOriginalDeck().getId());
-                result.put("originalDeckCardCount", player.getOriginalDeck().getCards().size());
-            }
-            
+
             return ResponseEntity.ok(result);
         } catch (Exception e) {
             result.put("error", "Failed to get player info: " + e.getMessage());

--- a/backend/src/main/java/com/cardgame/controller/player/PlayerController.java
+++ b/backend/src/main/java/com/cardgame/controller/player/PlayerController.java
@@ -46,8 +46,9 @@ public class PlayerController {
      * seat and the only reason this endpoint exists.
      *
      * <p>It still answers with the full PlayerDto, so a signed-in user can see more of a
-     * stranger than they need to. Narrowing it means giving hot-seat a shape of its own,
-     * which belongs with the wider work of moving game state off the Player document.
+     * stranger than they need to — less than it used to, now that a hand is not on the
+     * player, but still their deck and their lifetime score. Narrowing it means giving
+     * hot-seat a shape of its own.
      */
     @GetMapping("/by-name/{name}")
     public ResponseEntity<PlayerDto> getPlayerByName(@PathVariable String name) {

--- a/backend/src/main/java/com/cardgame/controller/player/PlayerController.java
+++ b/backend/src/main/java/com/cardgame/controller/player/PlayerController.java
@@ -34,18 +34,11 @@ public class PlayerController {
     // Removed auto-creation endpoint to prevent unauthorized player creation
     // Players should only be created through proper authentication flow
 
-    /** A player's own record. It carries their hand, so it is not somebody else's to read. */
+    /** A player's own record. It carries their deck, so it is not somebody else's to read. */
     @GetMapping("/{playerId}")
     public ResponseEntity<PlayerDto> getPlayer(@PathVariable String playerId) {
         currentUser.requireSelf(playerId);
         return ResponseEntity.ok(playerService.getPlayerDto(playerId));
-    }
-
-    @GetMapping("/game/players/{playerId}/hand")
-    public ResponseEntity<List<Card>> getPlayerHand(@PathVariable String playerId) {
-        currentUser.requireSelf(playerId);
-        Player player = playerService.getPlayer(playerId);
-        return ResponseEntity.ok(player.getHand());
     }
 
     /**

--- a/backend/src/main/java/com/cardgame/dto/PlayerDto.java
+++ b/backend/src/main/java/com/cardgame/dto/PlayerDto.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Map;
 
 @Value.Immutable
@@ -15,8 +14,6 @@ public interface PlayerDto {
 
     String getId();
     String getName();
-    int getScore();
-    int getHandSize();
 
     int getLifetimeScore();
 
@@ -25,15 +22,5 @@ public interface PlayerDto {
 
     // summary of placed cards
     Map<String, Integer> getPlayerCardCounts();
-
-    @Value.Default
-    default List<CardDto> getHand() {
-        return List.of();
-    }
-
-    @Value.Default
-    default Map<PositionDto, CardDto> getPlacedCards() {
-        return Map.of();
-    }
 
 }

--- a/backend/src/main/java/com/cardgame/model/GameModel.java
+++ b/backend/src/main/java/com/cardgame/model/GameModel.java
@@ -2,8 +2,10 @@ package com.cardgame.model;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +27,31 @@ public class GameModel {
     private String currentPlayerId;
 
     private List<String> playerIds;
+
+    /**
+     * Everything about a game that used to live on the players in it, keyed by player id.
+     *
+     * <p>Hands, placed cards and the deck were fields on {@code Player}, so a player could
+     * only be in one game at a time, a move wrote three documents, and a game that ended
+     * any way other than cleanly left the player holding a hand from it. Here a move is
+     * one read and one write of one document, and a crash loses nothing that was saved.
+     *
+     * <p>Keyed by player id rather than by seat, which means the same player cannot hold
+     * both sides of a game — see the guard in {@code NakamaMatchService.joinMatch}.
+     */
+    @Field("hands")
+    private Map<String, List<Card>> hands = new HashMap<>();
+
+    @Field("placed_cards")
+    private Map<String, Map<String, Card>> placedCards = new HashMap<>();
+
+    /**
+     * Denormalised at creation so that showing a game does not have to read its players.
+     * A rename after the fact will not reach a game already in progress, which is the
+     * trade being made: a name in a finished game is a record of what it was called then.
+     */
+    @Field("player_names")
+    private Map<String, String> playerNames = new HashMap<>();
 
     // Game result fields
     private String winnerId;
@@ -131,6 +158,84 @@ public class GameModel {
 
     public void setPlayerIds(List<String> playerIds) {
         this.playerIds = playerIds;
+    }
+
+    public Map<String, List<Card>> getHands() {
+        return hands;
+    }
+
+    public void setHands(Map<String, List<Card>> hands) {
+        this.hands = hands;
+    }
+
+    public Map<String, Map<String, Card>> getPlacedCards() {
+        return placedCards;
+    }
+
+    public void setPlacedCards(Map<String, Map<String, Card>> placedCards) {
+        this.placedCards = placedCards;
+    }
+
+    public Map<String, String> getPlayerNames() {
+        return playerNames;
+    }
+
+    public void setPlayerNames(Map<String, String> playerNames) {
+        this.playerNames = playerNames;
+    }
+
+    /**
+     * The player's hand, empty if they are not in this game.
+     *
+     * <p>Reading is the common path — a view of the game is built for every connected
+     * session on every move — so it must not create anything. Somebody looking at a game
+     * they are not playing should not quietly become a participant with no cards.
+     */
+    public List<Card> handOf(String playerId) {
+        List<Card> hand = hands == null ? null : hands.get(playerId);
+        return hand == null ? List.of() : hand;
+    }
+
+    /** The player's cards on the board, by position key. Empty if they have none. */
+    public Map<String, Card> placedCardsOf(String playerId) {
+        Map<String, Card> placed = placedCards == null ? null : placedCards.get(playerId);
+        return placed == null ? Map.of() : placed;
+    }
+
+    public String playerNameOf(String playerId) {
+        return playerNames == null ? null : playerNames.get(playerId);
+    }
+
+    /** Gives a player their opening hand, and records the name to show them under. */
+    public void seatPlayer(String playerId, String playerName, List<Card> hand) {
+        if (hands == null) {
+            hands = new HashMap<>();
+        }
+        if (playerNames == null) {
+            playerNames = new HashMap<>();
+        }
+        hands.put(playerId, new ArrayList<>(hand));
+        playerNames.put(playerId, playerName);
+    }
+
+    /**
+     * Moves a card out of a player's hand and onto the board.
+     *
+     * <p>The whole of a move, on one document. The board rejects a position that is
+     * occupied or off the edge; whether the player is allowed to place <em>there</em> is
+     * the validator's business, and has already been settled by the time this runs.
+     */
+    public void playCard(String playerId, Position position, Card card) {
+        if (hands == null) {
+            hands = new HashMap<>();
+        }
+        if (placedCards == null) {
+            placedCards = new HashMap<>();
+        }
+        board.placeCard(position, card.getId());
+        hands.computeIfAbsent(playerId, id -> new ArrayList<>()).remove(card);
+        placedCards.computeIfAbsent(playerId, id -> new HashMap<>())
+                .put(position.toStorageString(), card);
     }
 
     public String getWinnerId() {

--- a/backend/src/main/java/com/cardgame/model/Player.java
+++ b/backend/src/main/java/com/cardgame/model/Player.java
@@ -7,10 +7,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @Document(collection = "players")
 public class Player {
@@ -30,21 +26,13 @@ public class Player {
     @Indexed(unique = true)
     private String supabaseUserId;
 
+    /**
+     * The deck this player owns and plays with. A game no longer touches it: it reads the
+     * cards at the start and keeps the hand on itself, so nothing here changes for the
+     * length of a game and there is nothing to restore at the end of one.
+     */
     @DBRef(lazy = true)
     private Deck currentDeck;
-
-    @DBRef(lazy = true)
-    @Field("original_deck")
-    private Deck originalDeck;
-
-    @Field("hand")
-    private List<Card> hand = new ArrayList<>();
-
-    @Field("score")
-    private int score;
-
-    @Field("placed_cards")
-    private Map<String, Card> placedCards = new HashMap<>();
 
     @Field("lifetime_score")
     private int lifetimeScore = 0;
@@ -85,38 +73,6 @@ public class Player {
 
     public void setCurrentDeck(Deck currentDeck) {
         this.currentDeck = currentDeck;
-    }
-
-    public Deck getOriginalDeck() {
-        return originalDeck;
-    }
-
-    public void setOriginalDeck(Deck originalDeck) {
-        this.originalDeck = originalDeck;
-    }
-
-    public List<Card> getHand() {
-        return hand;
-    }
-
-    public void setHand(List<Card> hand) {
-        this.hand = hand;
-    }
-
-    public int getScore() {
-        return score;
-    }
-
-    public void setScore(int score) {
-        this.score = score;
-    }
-
-    public Map<String, Card> getPlacedCards() {
-        return placedCards;
-    }
-
-    public void setPlacedCards(Map<String, Card> placedCards) {
-        this.placedCards = placedCards;
     }
 
     public int getLifetimeScore() {

--- a/backend/src/main/java/com/cardgame/service/GameService.java
+++ b/backend/src/main/java/com/cardgame/service/GameService.java
@@ -37,7 +37,10 @@ import java.util.stream.Collectors;
 @Service
 public class GameService {
     private static final Logger logger = LoggerFactory.getLogger(GameService.class);
-    
+
+    /** Added to the winner's lifetime score when a game ends decisively. */
+    private static final int VICTORY_BONUS = 10;
+
     private final GameRepository gameRepository;
     private final PlayerService playerService;
     private final CardService cardService;
@@ -77,50 +80,25 @@ public class GameService {
     public GameDto convertToDto(GameModel gameModel) {
         return convertToDto(gameModel, gameModel.getCurrentPlayerId());
     }
-    
-    public GameDto convertToDto(GameModel gameModel, String forPlayerId) {
-        return convertToDto(gameModel, forPlayerId, loadPlayers(gameModel));
-    }
 
     /**
-     * Reads every player named by the game, once.
+     * Builds the view of a game for one player, from the game alone.
      *
-     * <p>A move is broadcast to each session in the match, and each of those needs a view
-     * of the game built for its own player. Converting per session re-read every player
-     * per conversion, so a two-player match cost six reads to send two messages. Loading
-     * them here and handing the same map to each conversion makes it two.
+     * <p>This used to read every player in the game, because the hands, the placed cards
+     * and the names were on them. It reads nothing now, which matters because a move is
+     * broadcast to every connected session and each session needs its own view: the cost
+     * of a broadcast no longer rises with the number of people watching.
      */
-    public Map<String, Player> loadPlayers(GameModel gameModel) {
-        Map<String, Player> players = new HashMap<>();
-        for (String playerId : gameModel.getPlayerIds()) {
-            players.put(playerId, playerService.getPlayer(playerId));
-        }
-        return players;
-    }
-
-    public GameDto convertToDto(GameModel gameModel, String forPlayerId, Map<String, Player> players) {
-        // forPlayerId is normally one of the game's players and already loaded; a
-        // spectator or an admin looking at somebody else's game is the exception.
-        Player currentPlayer = players.containsKey(forPlayerId)
-                ? players.get(forPlayerId)
-                : playerService.getPlayer(forPlayerId);
-
-        // Build card ownership map, collect all placed cards, and player names
+    public GameDto convertToDto(GameModel gameModel, String forPlayerId) {
+        // Build card ownership map and collect all placed cards
         Map<String, String> cardOwnership = new HashMap<>();
         Map<String, CardDto> placedCards = new HashMap<>();
-        Map<String, String> playerNames = new HashMap<>();
         for (String playerId : gameModel.getPlayerIds()) {
-            Player player = players.get(playerId);
-            // Add player name
-            playerNames.put(playerId, player.getName());
-            
-            if (player.getPlacedCards() != null) {
-                for (Map.Entry<String, Card> entry : player.getPlacedCards().entrySet()) {
-                    String position = entry.getKey();
-                    Card card = entry.getValue();
-                    cardOwnership.put(position, playerId);
-                    placedCards.put(card.getId(), convertCardToDto(card));
-                }
+            for (Map.Entry<String, Card> entry : gameModel.placedCardsOf(playerId).entrySet()) {
+                String position = entry.getKey();
+                Card card = entry.getValue();
+                cardOwnership.put(position, playerId);
+                placedCards.put(card.getId(), convertCardToDto(card));
             }
         }
 
@@ -134,13 +112,13 @@ public class GameService {
                         .pieces(gameModel.getBoard().getPieces())  // Use string keys directly
                         .build())
                 .currentPlayerId(gameModel.getCurrentPlayerId())
-                .currentPlayerHand(currentPlayer.getHand().stream()
+                .currentPlayerHand(gameModel.handOf(forPlayerId).stream()
                         .map(this::convertCardToDto)
                         .collect(Collectors.toList()))
                 .playerIds(gameModel.getPlayerIds())
                 .cardOwnership(cardOwnership)
                 .placedCards(placedCards)
-                .playerNames(playerNames)
+                .playerNames(gameModel.getPlayerNames())
                 .createdAt(gameModel.getCreatedAt())
                 .updatedAt(gameModel.getUpdatedAt());
 
@@ -168,7 +146,7 @@ public class GameService {
             }
         } else {
             // Game in progress - calculate current column scores
-            Map<Integer, ScoreCalculator.ColumnScore> columnScores = ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            Map<Integer, ScoreCalculator.ColumnScore> columnScores = ScoreCalculator.calculateColumnScores(gameModel);
             for (Map.Entry<Integer, ScoreCalculator.ColumnScore> entry : columnScores.entrySet()) {
                 ScoreCalculator.ColumnScore colScore = entry.getValue();
                 ColumnScoreDto dto = ImmutableColumnScoreDto.builder()
@@ -257,9 +235,9 @@ public class GameService {
         gameModel.setPlayerIds(playerIds);
         gameModel.setCurrentPlayerId(player1Id); // player1 starts first
 
-        // set up players' game state with their chosen decks
-        setupPlayerGameState(player1Id, deck1Id);
-        setupPlayerGameState(player2Id, deck2Id);
+        // deal each player into the game itself, rather than onto their player document
+        dealIntoGame(gameModel, player1Id, deck1Id);
+        dealIntoGame(gameModel, player2Id, deck2Id);
 
         placeInitialCards(gameModel, player1Id, player2Id);
 
@@ -274,52 +252,33 @@ public class GameService {
         return convertToDto(gameModel);
     }
 
-    private void setupPlayerGameState(String playerId, String deckId) {
+    /**
+     * Deals a player their opening hand out of the deck they chose.
+     *
+     * <p>The deck is read and left alone. It used to be copied into a temporary deck that
+     * was never saved and then written over the player's {@code currentDeck}, which is
+     * why finishing a game had to put the real one back — and why a game that never
+     * finished left the player pointing at a deck document that does not exist. The whole
+     * arrangement bought nothing: a deck is five cards and a hand is five cards, so the
+     * copy was empty from the moment it was made.
+     */
+    private void dealIntoGame(GameModel gameModel, String playerId, String deckId) {
         Player player = playerService.getPlayer(playerId);
-        Deck originalDeck = deckService.getDeck(deckId);
+        Deck deck = deckService.getDeck(deckId);
 
-        // Store reference to original deck for restoration after game
-        player.setOriginalDeck(originalDeck);
-
-        // Create a temporary copy of the deck for this game (in memory only - don't save to DB)
-        Deck gameDeck = new Deck();
-        gameDeck.setId(UUID.randomUUID().toString());
-        gameDeck.setOwnerId(playerId);
-        gameDeck.setCards(new ArrayList<>(originalDeck.getCards())); // Copy cards from original deck
-        gameDeck.setRemainingCards(originalDeck.getCards().size());
-
-        // Note: NOT saving gameDeck to database - it's temporary for this game only
-
-        // Draw initial hand (5 cards)
-        List<Card> initialHand = new ArrayList<>(gameDeck.getCards().subList(0, 5));
-        gameDeck.getCards().subList(0, 5).clear();
-        gameDeck.setRemainingCards(gameDeck.getCards().size());
-
-        // Update player's game state with temporary deck
-        player.setCurrentDeck(gameDeck);
-        player.setHand(initialHand);
-        player.setScore(0);
-        player.setPlacedCards(new HashMap<>());
-
-        // Save updated player state (includes originalDeck reference)
-        playerService.savePlayer(player);
+        gameModel.seatPlayer(playerId, player.getName(), new ArrayList<>(deck.getCards()));
     }
 
     private void placeInitialCards(GameModel gameModel, String player1Id, String player2Id) {
-        Board board = gameModel.getBoard();
-
-        placeInitialCardForPlayer(player1Id, new Position(1, 3), board);
-        placeInitialCardForPlayer(player2Id, new Position(1, 1), board);
+        placeInitialCardForPlayer(gameModel, player1Id, new Position(1, 3));
+        placeInitialCardForPlayer(gameModel, player2Id, new Position(1, 1));
     }
 
-    private void placeInitialCardForPlayer(String playerId, Position position, Board board) {
-        Player player = playerService.getPlayer(playerId);
+    private void placeInitialCardForPlayer(GameModel gameModel, String playerId, Position position) {
         // Randomly select a card from the player's hand
-        int randomIndex = (int) (Math.random() * player.getHand().size());
-        Card card = player.getHand().remove(randomIndex);
-        boardManager.placeCard(board, position, card.getId());
-        player.getPlacedCards().put(position.toStorageString(), card);
-        playerService.savePlayer(player);
+        List<Card> hand = gameModel.handOf(playerId);
+        Card card = hand.get((int) (Math.random() * hand.size()));
+        gameModel.playCard(playerId, position, card);
     }
 
     /**
@@ -427,33 +386,33 @@ public class GameService {
 
     private boolean anyPlayerHasValidMoves(GameModel gameModel) {
         for (String playerId : gameModel.getPlayerIds()) {
-            Player player = playerService.getPlayer(playerId);
-            if (!player.getHand().isEmpty() && hasValidMoves(gameModel, player)) {
+            if (hasValidMoves(gameModel, playerId)) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean hasValidMoves(GameModel gameModel, Player player) {
-        List<Position> emptyPositions = gameModel.getBoard().getEmptyPositions();
+    private boolean hasValidMoves(GameModel gameModel, String playerId) {
+        List<Card> hand = gameModel.handOf(playerId);
+        if (hand.isEmpty()) {
+            return false;
+        }
 
-        for (Position pos : emptyPositions) {
-            if (!player.getHand().isEmpty()) {
-                PlayerAction testAction = ImmutablePlayerAction.builder()
-                        .type(PlayerAction.ActionType.PLACE_CARD)
-                        .playerId(player.getId())
-                        .targetPosition(pos)
-                        .card(player.getHand().get(0))
-                        .timestamp(System.currentTimeMillis())
-                        .build();
+        for (Position pos : gameModel.getBoard().getEmptyPositions()) {
+            PlayerAction testAction = ImmutablePlayerAction.builder()
+                    .type(PlayerAction.ActionType.PLACE_CARD)
+                    .playerId(playerId)
+                    .targetPosition(pos)
+                    .card(hand.get(0))
+                    .timestamp(System.currentTimeMillis())
+                    .build();
 
-                try {
-                    gameValidator.validateMove(gameModel, testAction);
-                    return true;
-                } catch (Exception e) {
-                    // Continue checking other positions
-                }
+            try {
+                gameValidator.validateMove(gameModel, testAction);
+                return true;
+            } catch (InvalidMoveException e) {
+                // Continue checking other positions
             }
         }
         return false;
@@ -473,114 +432,69 @@ public class GameService {
         metricsConfig.decrementActiveGames();
         logger.info("Game completed with ID: {}", gameModel.getId());
 
-        // IMPORTANT: Calculate column scores BEFORE restoring player state (which clears placedCards)
-        Map<Integer, ScoreCalculator.ColumnScore> columnScores = ScoreCalculator.calculateColumnScores(gameModel, playerService);
-        
+        Map<Integer, ScoreCalculator.ColumnScore> columnScores = ScoreCalculator.calculateColumnScores(gameModel);
+
         // Store column scores in the game model for final display
         Map<Integer, Map<String, Integer>> finalColumnScores = new HashMap<>();
         for (Map.Entry<Integer, ScoreCalculator.ColumnScore> entry : columnScores.entrySet()) {
             finalColumnScores.put(entry.getKey(), entry.getValue().playerScores);
         }
         gameModel.setFinalColumnScores(finalColumnScores);
-        
-        // Determine winner using column-based scoring
-        String winnerId = ScoreCalculator.determineWinner(gameModel, playerService);
+
+        // Determine winner using column-based scoring. This also records the columns each
+        // player won on the game, which is what playerScores is for — it used to be
+        // overwritten with zeroes immediately afterwards, by a loop reading a per-game
+        // score on Player that nothing ever set.
+        String winnerId = ScoreCalculator.determineWinner(gameModel);
         gameModel.setWinnerId(winnerId);
         gameModel.setTie(winnerId == null);
 
-        // Get all players for this game
-        Map<String, Player> players = new HashMap<>();
+        // A finished game touches its players once each, for the one thing that genuinely
+        // belongs to them and outlives the game.
+        settleLifetimeScores(gameModel, winnerId);
+    }
+
+    /**
+     * Adds the victory bonus to the winner, and puts every player on the leaderboard.
+     *
+     * <p>Only the winner's total changes. Every player used to be written as well, but
+     * the amount added was the per-game score on {@code Player}, which was always zero:
+     * the method meant to maintain it had been a no-op since scoring moved to columns.
+     * Every player is still <em>submitted</em>, so that somebody who has yet to win a
+     * game still appears on the leaderboard rather than being absent from it.
+     */
+    private void settleLifetimeScores(GameModel gameModel, String winnerId) {
+        boolean hasWinner = winnerId != null && !gameModel.isTie();
+
         for (String playerId : gameModel.getPlayerIds()) {
             Player player = playerService.getPlayer(playerId);
-            players.put(playerId, player);
 
-            // Calculate and update player scores for this game
-            ScoreCalculator.updatePlayerScore(player, gameModel);
-
-            // Add the current game score to lifetime score
-            int gameScore = player.getScore();
-            player.addLifetimeScore(gameScore);
-
-            // Store scores in the game model
-            gameModel.updatePlayerScore(playerId, gameScore);
-
-            // Restore player's original deck and clean up temporary game state
-            restorePlayerOriginalState(player);
-
-            // Save player with updated lifetime score and restored original deck
-            // Use updatePlayerSafely to prevent accidental data loss
-            playerService.updatePlayerSafely(player.getId(), p -> {
-                // Copy the updated state from the player object
-                p.setLifetimeScore(player.getLifetimeScore());
-                p.setCurrentDeck(player.getCurrentDeck());
-                p.setOriginalDeck(player.getOriginalDeck());
-                p.setHand(player.getHand());
-                p.setPlacedCards(player.getPlacedCards());
-                p.setScore(player.getScore());
-            });
-
-            // Submit lifetime score to leaderboard if player has a Nakama user ID
-            if (player.getNakamaUserId() != null && !player.getNakamaUserId().isEmpty()) {
-                nakamaLeaderBoardService.submitPlayerScore(player.getNakamaUserId(), player.getLifetimeScore(), 
-                    player.getName());
-            }
-        }
-
-        // Award bonus points to the winner's lifetime score
-        if (winnerId != null && !gameModel.isTie()) {
-            Player winner = players.get(winnerId);
-            if (winner != null) {
-                // Add a victory bonus to lifetime score (e.g., 10 points)
-                int victoryBonus = 10;
-                winner.addLifetimeScore(victoryBonus);
-                
+            if (hasWinner && playerId.equals(winnerId)) {
+                player.addLifetimeScore(VICTORY_BONUS);
                 // Use updatePlayerSafely to prevent accidental data loss
-                playerService.updatePlayerSafely(winner.getId(), p -> {
-                    p.setLifetimeScore(winner.getLifetimeScore());
-                });
+                playerService.updatePlayerSafely(playerId, p -> p.setLifetimeScore(player.getLifetimeScore()));
+            }
 
-                // Update leaderboard with the new lifetime score including victory bonus
-                if (winner.getNakamaUserId() != null && !winner.getNakamaUserId().isEmpty()) {
-                    nakamaLeaderBoardService.submitPlayerScore(winner.getNakamaUserId(), winner.getLifetimeScore(), 
-                        winner.getName());
-                }
+            if (player.getNakamaUserId() != null && !player.getNakamaUserId().isEmpty()) {
+                nakamaLeaderBoardService.submitPlayerScore(player.getNakamaUserId(), player.getLifetimeScore(),
+                    player.getName());
             }
         }
     }
 
     private void handleTurnSwitching(GameModel gameModel) {
         String currentPlayerId = gameModel.getCurrentPlayerId();
-        Player currentPlayer = playerService.getPlayer(currentPlayerId);
-        
+
         // Try to switch to next player first
         switchToNextPlayer(gameModel);
-        String nextPlayerId = gameModel.getCurrentPlayerId();
-        Player nextPlayer = playerService.getPlayer(nextPlayerId);
-        
+
         // If next player has no valid moves, check if current player can continue
-        if (nextPlayer.getHand().isEmpty() || !hasValidMoves(gameModel, nextPlayer)) {
-            // Switch back to current player if they still have valid moves
-            if (!currentPlayer.getHand().isEmpty() && hasValidMoves(gameModel, currentPlayer)) {
-                gameModel.setCurrentPlayerId(currentPlayerId);
-            }
-            // If both players have no valid moves, the game will end on next check
+        if (!hasValidMoves(gameModel, gameModel.getCurrentPlayerId())
+                && hasValidMoves(gameModel, currentPlayerId)) {
+            // Switch back to current player if they still have valid moves.
+            // If neither can move, the game will end on the next check.
+            gameModel.setCurrentPlayerId(currentPlayerId);
         }
-    }
-
-    /**
-     * Restore player's original deck and clean up temporary game state
-     */
-    private void restorePlayerOriginalState(Player player) {
-        // Restore original deck reference
-        if (player.getOriginalDeck() != null) {
-            player.setCurrentDeck(player.getOriginalDeck());
-            player.setOriginalDeck(null); // Clear temporary reference
-        }
-
-        // Clean up temporary game state
-        player.setHand(new ArrayList<>()); // Clear hand
-        player.setPlacedCards(new HashMap<>()); // Clear placed cards
-        player.setScore(0); // Reset game score (lifetime score already updated)
     }
 
     private void switchToNextPlayer(GameModel gameModel) {

--- a/backend/src/main/java/com/cardgame/service/factory/MoveStrategyFactory.java
+++ b/backend/src/main/java/com/cardgame/service/factory/MoveStrategyFactory.java
@@ -1,8 +1,6 @@
 package com.cardgame.service.factory;
 
 import com.cardgame.dto.PlayerAction;
-import com.cardgame.service.manager.BoardManager;
-import com.cardgame.service.player.PlayerService;
 import com.cardgame.service.strategy.MoveStrategy;
 import com.cardgame.service.strategy.PassStrategy;
 import com.cardgame.service.strategy.PlaceCardStrategy;
@@ -12,17 +10,10 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MoveStrategyFactory {
-    private final PlayerService playerService;
-    private final BoardManager boardManager;
-
-    public MoveStrategyFactory(PlayerService playerService, BoardManager boardManager) {
-        this.playerService = playerService;
-        this.boardManager = boardManager;
-    }
 
     public MoveStrategy createStrategy(PlayerAction.ActionType actionType) {
         return switch (actionType) {
-            case PLACE_CARD -> new PlaceCardStrategy(playerService, boardManager);
+            case PLACE_CARD -> new PlaceCardStrategy();
             case PASS -> new PassStrategy();
             case REQUEST_WIN_CALCULATION -> new WinRequestStrategy();
             case RESPOND_TO_WIN_REQUEST -> new WinResponseStrategy();

--- a/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
+++ b/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
@@ -120,10 +120,19 @@ public class NakamaMatchService {
                 if (!"WAITING".equals(metadata.status)) {
                     throw new IllegalArgumentException("Match already started or completed");
                 }
-                
+
+                // A game is between two players, and everything about it is keyed by player
+                // id — the hands, the cards each has on the board, whose turn it is. One
+                // person on both sides collapses to a single set of those, which is not a
+                // game so much as a way to corrupt one. This has to be refused before the
+                // line below, which would otherwise clear the creator out of their own match.
+                if (playerId.equals(metadata.creatorId)) {
+                    throw new IllegalArgumentException("Cannot join your own match");
+                }
+
                 // Clear any existing matches for this player first
                 clearPlayerFromActiveMatches(playerId);
-                
+
                 // Get the creator's ID from metadata
                 String creatorId = metadata.creatorId;
                 

--- a/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
+++ b/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
@@ -148,43 +148,12 @@ public class NakamaMatchService {
                 Player player1 = playerService.getPlayer(creatorId);
                 Player player2 = playerService.getPlayer(playerId);
                 
-                // Ensure players have current decks set
-                if (player1.getCurrentDeck() == null && player1.getOriginalDeck() != null) {
-                    player1.setCurrentDeck(player1.getOriginalDeck());
-                    playerService.savePlayer(player1);
-                    logger.info("Set current deck for player1 from original deck");
-                }
-                
-                if (player2.getCurrentDeck() == null && player2.getOriginalDeck() != null) {
-                    player2.setCurrentDeck(player2.getOriginalDeck());
-                    playerService.savePlayer(player2);
-                    logger.info("Set current deck for player2 from original deck");
-                }
-                
-                // Get deck IDs - handle lazy loading issues
-                String deck1Id = null;
-                String deck2Id = null;
-                
-                // For player 1
-                if (player1.getCurrentDeck() != null && player1.getCurrentDeck().getId() != null) {
-                    deck1Id = player1.getCurrentDeck().getId();
-                } else if (player1.getOriginalDeck() != null && player1.getOriginalDeck().getId() != null) {
-                    deck1Id = player1.getOriginalDeck().getId();
-                    logger.info("Using original deck ID for player1 due to lazy loading");
-                } else {
-                    throw new RuntimeException("Player 1 has no deck available");
-                }
-                
-                // For player 2
-                if (player2.getCurrentDeck() != null && player2.getCurrentDeck().getId() != null) {
-                    deck2Id = player2.getCurrentDeck().getId();
-                } else if (player2.getOriginalDeck() != null && player2.getOriginalDeck().getId() != null) {
-                    deck2Id = player2.getOriginalDeck().getId();
-                    logger.info("Using original deck ID for player2 due to lazy loading");
-                } else {
-                    throw new RuntimeException("Player 2 has no deck available");
-                }
-                
+                // A player's deck is simply their deck now. All of the falling back to
+                // originalDeck that used to be here was working around the game writing an
+                // unsaved temporary deck over currentDeck, which it no longer does.
+                String deck1Id = deckIdOf(player1);
+                String deck2Id = deckIdOf(player2);
+
                 logger.info("Using decks - player1: {}, player2: {}", deck1Id, deck2Id);
                 
                 // Initialize the game - this returns GameDto
@@ -526,6 +495,13 @@ public class NakamaMatchService {
     
     private String generateMatchId() {
         return UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+    }
+
+    private String deckIdOf(Player player) {
+        if (player.getCurrentDeck() == null || player.getCurrentDeck().getId() == null) {
+            throw new IllegalStateException("Player " + player.getId() + " has no deck available");
+        }
+        return player.getCurrentDeck().getId();
     }
     
     /**

--- a/backend/src/main/java/com/cardgame/service/player/PlayerService.java
+++ b/backend/src/main/java/com/cardgame/service/player/PlayerService.java
@@ -74,9 +74,7 @@ public class PlayerService {
         return ImmutablePlayerDto.builder()
                 .id(player.getId())
                 .name(player.getName())
-                .score(player.getScore())
                 .lifetimeScore(player.getLifetimeScore()) // Include lifetime score in DTO
-                .handSize(player.getHand().size())
                 .currentDeck(deckDto)
                 .playerCardCounts(calculatePlayerCardCounts(player))
                 .build();
@@ -86,36 +84,6 @@ public class PlayerService {
     private Map<String, Integer> calculatePlayerCardCounts(Player player) {
         // For now, return an empty map since we're just starting
         return Map.of();
-    }
-
-    public void addCardToHand(PlayerDto player, CardDto card) {
-        List<CardDto> currentHand = player.getHand();
-        currentHand.add(card);
-        ImmutablePlayerDto.builder()
-                .from(player)
-                .hand(currentHand);
-    }
-
-    public void removeCardFromHand(PlayerDto player, CardDto card) {
-        List<CardDto> currentHand = player.getHand();
-        currentHand.remove(card);
-        ImmutablePlayerDto.builder()
-                .from(player)
-                .hand(currentHand);
-    }
-
-    public void placeCard(PlayerDto player, CardDto card, PositionDto position) {
-        // Create a card placement action
-        PlayerAction action = playerActionService.placeCard(player.getId(), card, position);
-
-        // Update the player's placed cards
-        Map<PositionDto, CardDto> currentPlacedCards = new HashMap<>(player.getPlacedCards());
-        currentPlacedCards.put(position, card);
-
-        // Build the updated PlayerDto
-        ImmutablePlayerDto.builder()
-                .from(player)
-                .placedCards(currentPlacedCards);
     }
 
     public void savePlayer(Player player) {
@@ -329,10 +297,7 @@ public class PlayerService {
             player.setEmail(email);
             player.setSupabaseUserId(supabaseUserId);
             player.setNakamaUserId(nakamaUserId);
-            player.setScore(0);
             player.setLifetimeScore(0);
-            player.setHand(new ArrayList<>());
-            player.setPlacedCards(new HashMap<>());
 
             // Save player first to get the ID
             player = playerRepository.save(player);

--- a/backend/src/main/java/com/cardgame/service/strategy/PlaceCardStrategy.java
+++ b/backend/src/main/java/com/cardgame/service/strategy/PlaceCardStrategy.java
@@ -1,39 +1,20 @@
 package com.cardgame.service.strategy;
 
 import com.cardgame.dto.PlayerAction;
-import com.cardgame.dto.PositionDto;
-import com.cardgame.model.Card;
 import com.cardgame.model.GameModel;
-import com.cardgame.model.Player;
-import com.cardgame.model.Position;
-import com.cardgame.service.manager.BoardManager;
-import com.cardgame.service.player.PlayerService;
-import com.cardgame.service.util.ScoreCalculator;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PlaceCardStrategy implements MoveStrategy {
-    private final PlayerService playerService;
-    private final BoardManager boardManager;
 
-    public PlaceCardStrategy(PlayerService playerService, BoardManager boardManager) {
-        this.playerService = playerService;
-        this.boardManager = boardManager;
-    }
-
+    /**
+     * Plays a card onto the board.
+     *
+     * <p>Hand and board are both on the game, so this changes one object and saves
+     * nothing — the caller writes the game once, whatever the move was.
+     */
     @Override
     public void executeMove(GameModel gameModel, PlayerAction action) {
-        Player player = playerService.getPlayer(action.getPlayerId());
-        Card card = action.getCard();
-        Position position = action.getTargetPosition();
-
-        player.getHand().remove(card);
-        boardManager.placeCard(gameModel.getBoard(), position, card.getId());
-        player.getPlacedCards().put(position.toStorageString(), card);
-
-        // Update player score after placing the card
-        ScoreCalculator.updatePlayerScore(player, gameModel);
-
-        playerService.savePlayer(player);
+        gameModel.playCard(action.getPlayerId(), action.getTargetPosition(), action.getCard());
     }
 }

--- a/backend/src/main/java/com/cardgame/service/tutorial/TutorialBotService.java
+++ b/backend/src/main/java/com/cardgame/service/tutorial/TutorialBotService.java
@@ -3,9 +3,7 @@ package com.cardgame.service.tutorial;
 import com.cardgame.model.Board;
 import com.cardgame.model.Card;
 import com.cardgame.model.GameModel;
-import com.cardgame.model.Player;
 import com.cardgame.model.Position;
-import com.cardgame.service.player.PlayerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -22,12 +20,6 @@ import java.util.Random;
 public class TutorialBotService {
     private static final Logger logger = LoggerFactory.getLogger(TutorialBotService.class);
     private static final Random random = new Random();
-    
-    private final PlayerService playerService;
-
-    public TutorialBotService(PlayerService playerService) {
-        this.playerService = playerService;
-    }
 
     /**
      * Make a move for the tutorial bot
@@ -37,9 +29,9 @@ public class TutorialBotService {
      */
     public BotMove makeBotMove(GameModel gameModel, String botPlayerId) {
         logger.info("Tutorial bot making move for player: {}", botPlayerId);
-        
-        Player botPlayer = playerService.getPlayer(botPlayerId);
-        if (botPlayer.getHand() == null || botPlayer.getHand().isEmpty()) {
+
+        List<Card> hand = gameModel.handOf(botPlayerId);
+        if (hand.isEmpty()) {
             logger.warn("Bot has no cards in hand");
             return null;
         }
@@ -53,7 +45,7 @@ public class TutorialBotService {
 
         // Simple bot strategy: prefer middle columns, then random
         Position chosenPosition = chooseBestPosition(availablePositions);
-        Card chosenCard = chooseBestCard(botPlayer.getHand(), chosenPosition);
+        Card chosenCard = chooseBestCard(hand, chosenPosition);
 
         logger.info("Bot chose card '{}' (power: {}) at position ({}, {})", 
                    chosenCard.getName(), chosenCard.getPower(), 
@@ -124,14 +116,14 @@ public class TutorialBotService {
      * Check if bot should pass (simple logic - pass if hand is very weak)
      */
     public boolean shouldBotPass(GameModel gameModel, String botPlayerId) {
-        Player botPlayer = playerService.getPlayer(botPlayerId);
-        
-        if (botPlayer.getHand() == null || botPlayer.getHand().isEmpty()) {
+        List<Card> hand = gameModel.handOf(botPlayerId);
+
+        if (hand.isEmpty()) {
             return true;
         }
-        
+
         // Bot passes if all cards in hand are very weak (power < 2)
-        boolean allWeak = botPlayer.getHand().stream()
+        boolean allWeak = hand.stream()
                 .allMatch(card -> card.getPower() < 2);
         
         // Add some randomness - bot might pass 20% of the time even with good cards

--- a/backend/src/main/java/com/cardgame/service/util/ScoreCalculator.java
+++ b/backend/src/main/java/com/cardgame/service/util/ScoreCalculator.java
@@ -2,12 +2,9 @@ package com.cardgame.service.util;
 
 import com.cardgame.model.Card;
 import com.cardgame.model.GameModel;
-import com.cardgame.model.Player;
 import com.cardgame.model.Position;
-import com.cardgame.service.player.PlayerService;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -15,7 +12,7 @@ import java.util.Map;
  * Each column is scored independently, and the winner is determined by who wins the most columns.
  */
 public class ScoreCalculator {
-    
+
     /**
      * Column score data containing the score for each player in a column
      */
@@ -23,24 +20,23 @@ public class ScoreCalculator {
         public Map<String, Integer> playerScores = new HashMap<>();
         public String winnerId = null;
         public boolean isTie = false;
-        
+
         public ColumnScore() {
             // Initialize with empty scores
         }
     }
-    
+
     /**
      * Calculate column scores for the current game state
      * @param gameModel The game model
-     * @param playerService Service to retrieve player data
      * @return Map of column index to ColumnScore
      */
-    public static Map<Integer, ColumnScore> calculateColumnScores(GameModel gameModel, PlayerService playerService) {
+    public static Map<Integer, ColumnScore> calculateColumnScores(GameModel gameModel) {
         Map<Integer, ColumnScore> columnScores = new HashMap<>();
-        
+
         // Get board width dynamically from the game model
         int boardWidth = gameModel.getBoard().getWidth();
-        
+
         // Initialize column scores for each column
         for (int col = 0; col < boardWidth; col++) {
             ColumnScore colScore = new ColumnScore();
@@ -50,36 +46,33 @@ public class ScoreCalculator {
             }
             columnScores.put(col, colScore);
         }
-        
+
         // Calculate scores for each player
         for (String playerId : gameModel.getPlayerIds()) {
-            Player player = playerService.getPlayer(playerId);
-            Map<String, Card> placedCards = player.getPlacedCards();
-            
-            if (placedCards != null) {
-                for (Map.Entry<String, Card> entry : placedCards.entrySet()) {
-                    String positionKey = entry.getKey();
-                    Card card = entry.getValue();
-                    
-                    // Parse position to get column
-                    Position pos = Position.fromStorageString(positionKey);
-                    int column = pos.getX();
-                    
-                    // Add card power to player's column score
-                    ColumnScore colScore = columnScores.get(column);
-                    colScore.playerScores.merge(playerId, card.getPower(), Integer::sum);
-                }
+            Map<String, Card> placedCards = gameModel.placedCardsOf(playerId);
+
+            for (Map.Entry<String, Card> entry : placedCards.entrySet()) {
+                String positionKey = entry.getKey();
+                Card card = entry.getValue();
+
+                // Parse position to get column
+                Position pos = Position.fromStorageString(positionKey);
+                int column = pos.getX();
+
+                // Add card power to player's column score
+                ColumnScore colScore = columnScores.get(column);
+                colScore.playerScores.merge(playerId, card.getPower(), Integer::sum);
             }
         }
-        
+
         // Determine winner for each column
         for (ColumnScore colScore : columnScores.values()) {
             determineColumnWinner(colScore);
         }
-        
+
         return columnScores;
     }
-    
+
     /**
      * Determine the winner of a single column
      * @param columnScore The column score to evaluate
@@ -89,11 +82,11 @@ public class ScoreCalculator {
         String winnerId = null;
         boolean isTie = false;
         int playersWithHighestScore = 0;
-        
+
         for (Map.Entry<String, Integer> entry : columnScore.playerScores.entrySet()) {
             String playerId = entry.getKey();
             int score = entry.getValue();
-            
+
             if (score > highestScore) {
                 highestScore = score;
                 winnerId = playerId;
@@ -102,66 +95,70 @@ public class ScoreCalculator {
                 playersWithHighestScore++;
             }
         }
-        
+
         // If multiple players have the highest score, it's a tie
         isTie = playersWithHighestScore > 1;
-        
+
         // If highest score is 0, it's also considered a tie (empty column).
         // This is the intended behavior as per game design, even if cards with power 0 are placed.
         if (highestScore == 0) {
             isTie = true;
             winnerId = null;
         }
-        
+
         columnScore.winnerId = isTie ? null : winnerId;
         columnScore.isTie = isTie;
     }
 
     /**
-     * Updates player scores based on column wins.
-     * The score is now the number of columns won.
+     * Counts the columns each player has won.
+     *
+     * @param columnScores The per-column scores
+     * @param playerIds Every player in the game, so that one who has won nothing still
+     *                  appears with a zero rather than being absent
+     * @return Map of player id to the number of columns they have won
      */
-    public static void updatePlayerScore(Player player, GameModel gameModel) {
-        // This method is called for backward compatibility
-        // Actual scoring is now based on columns won, calculated in determineWinner
+    public static Map<String, Integer> countColumnsWon(Map<Integer, ColumnScore> columnScores,
+                                                       Iterable<String> playerIds) {
+        Map<String, Integer> columnsWon = new HashMap<>();
+        for (String playerId : playerIds) {
+            columnsWon.put(playerId, 0);
+        }
+
+        for (ColumnScore colScore : columnScores.values()) {
+            if (colScore.winnerId != null && !colScore.isTie) {
+                columnsWon.merge(colScore.winnerId, 1, Integer::sum);
+            }
+        }
+
+        return columnsWon;
     }
 
     /**
      * Determines the winner of the game based on column victories.
      * The player who wins the most columns (2 out of 3) wins the game.
      *
+     * <p>Records the columns won on the game as it goes, which is what
+     * {@code playerScores} has always been meant to hold.
+     *
      * @param gameModel The game model
-     * @param playerService Service to retrieve player data
      * @return The ID of the winning player, or null if there's a tie
      */
-    public static String determineWinner(GameModel gameModel, PlayerService playerService) {
-        Map<Integer, ColumnScore> columnScores = calculateColumnScores(gameModel, playerService);
-        
-        // Count columns won by each player
-        Map<String, Integer> columnsWon = new HashMap<>();
-        for (String playerId : gameModel.getPlayerIds()) {
-            columnsWon.put(playerId, 0);
-        }
-        
-        // Count column victories
-        for (ColumnScore colScore : columnScores.values()) {
-            if (colScore.winnerId != null && !colScore.isTie) {
-                columnsWon.merge(colScore.winnerId, 1, Integer::sum);
-            }
-        }
-        
-        // Update game scores with columns won
+    public static String determineWinner(GameModel gameModel) {
+        Map<Integer, ColumnScore> columnScores = calculateColumnScores(gameModel);
+        Map<String, Integer> columnsWon = countColumnsWon(columnScores, gameModel.getPlayerIds());
+
         gameModel.setScores(new HashMap<>(columnsWon));
-        
+
         // Determine overall winner (who won most columns)
         int mostColumnsWon = -1;
         String gameWinner = null;
         boolean isGameTie = false;
-        
+
         for (Map.Entry<String, Integer> entry : columnsWon.entrySet()) {
             String playerId = entry.getKey();
             int columns = entry.getValue();
-            
+
             if (columns > mostColumnsWon) {
                 mostColumnsWon = columns;
                 gameWinner = playerId;
@@ -170,17 +167,7 @@ public class ScoreCalculator {
                 isGameTie = true;
             }
         }
-        
+
         return isGameTie ? null : gameWinner;
-    }
-    
-    /**
-     * @deprecated This method is retained for backward compatibility but does nothing.
-     * Use {@link #determineWinner(GameModel, PlayerService)} for scoring logic.
-     */
-    @Deprecated
-    public static String determineWinner(GameModel gameModel) {
-        // This should not be called anymore, but kept for compatibility
-        throw new UnsupportedOperationException("Use determineWinner(GameModel, PlayerService) instead");
     }
 }

--- a/backend/src/main/java/com/cardgame/service/validator/DefaultGameValidator.java
+++ b/backend/src/main/java/com/cardgame/service/validator/DefaultGameValidator.java
@@ -2,6 +2,8 @@ package com.cardgame.service.validator;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import com.cardgame.dto.PlayerAction;
 import com.cardgame.exception.game.InvalidMoveException;
 import com.cardgame.model.Card;
@@ -64,41 +66,40 @@ public class DefaultGameValidator implements GameValidator {
         }
     }
 
+    /**
+     * Validates a placement against the game alone.
+     *
+     * <p>This used to load the player to reach their hand and their cards on the board.
+     * Both are on the game now, so validating a move reads nothing.
+     */
     @Override
     public void validateMove(GameModel gameModel, PlayerAction action) {
         Position targetPos = action.getTargetPosition();
         Card card = action.getCard();
-        Player player = playerService.getPlayer(action.getPlayerId());
+        String playerId = action.getPlayerId();
 
         if (!boardManager.isValidPosition(gameModel.getBoard(), targetPos)) {
             throw new InvalidMoveException("Invalid or occupied position");
         }
 
-        if (!player.getHand().contains(card)) {
+        if (!gameModel.handOf(playerId).contains(card)) {
             throw new InvalidMoveException("Card not in player's hand");
         }
 
-        validateCardPlacement(gameModel, player, targetPos);
-    }
-
-    private void validateCardPlacement(GameModel gameModel, Player player, Position targetPos) {
         // After game initialization, players always have cards on board, so adjacency rules always apply
-        validateAdjacentPlacement(gameModel, player, targetPos);
+        validateAdjacentPlacement(gameModel, playerId, targetPos);
     }
 
-    private void validateFirstMove(Position pos, String playerId, GameModel gameModel) {
-        // For the first move after initial placement, any empty position is valid
-        // since cards are already placed at initialization
-        // The adjacency rule will apply from the second move onwards
-    }
+    private void validateAdjacentPlacement(GameModel gameModel, String playerId, Position targetPos) {
+        Set<String> ownCardIds = gameModel.placedCardsOf(playerId).values().stream()
+                .map(Card::getId)
+                .collect(Collectors.toSet());
 
-    private void validateAdjacentPlacement(GameModel gameModel, Player player, Position targetPos) {
         List<Position> adjacentPositions = boardManager.getAdjacentPositions(gameModel.getBoard(), targetPos);
         boolean hasAdjacentCard = adjacentPositions.stream()
                 .map(pos -> gameModel.getBoard().getCardIdAt(pos))
                 .filter(Objects::nonNull)
-                .anyMatch(cardId -> player.getPlacedCards().values().stream()
-                        .anyMatch(c -> c.getId().equals(cardId)));
+                .anyMatch(ownCardIds::contains);
 
         if (!hasAdjacentCard) {
             throw new InvalidMoveException("Must place card adjacent to your existing cards");

--- a/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
+++ b/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
@@ -303,15 +303,13 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
             // Broadcast updated game state to all players in the match
             Set<WebSocketSession> sessions = matchSessions.get(info.matchId);
             if (sessions != null) {
-                // Read each player once for the whole broadcast instead of once per
-                // conversion. This is the hot path: it runs on every move, for every
-                // connected socket.
-                var players = gameService.loadPlayers(updatedGame);
                 for (WebSocketSession s : sessions) {
                     SessionInfo sInfo = sessionInfoMap.get(s.getId());
                     if (sInfo != null) {
-                        // Get game DTO specific to each player
-                        var playerGameDto = gameService.convertToDto(updatedGame, sInfo.playerId, players);
+                        // Get game DTO specific to each player. Building this reads
+                        // nothing now that the game carries its own state, so the hot
+                        // path costs one write of one document however many are watching.
+                        var playerGameDto = gameService.convertToDto(updatedGame, sInfo.playerId);
                         sendMessage(s, new WebSocketMessage(
                             MessageType.GAME_STATE_UPDATE,
                             playerGameDto

--- a/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
@@ -397,18 +397,13 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
         assertDeckUndisturbed(originalDeck1Id, originalDeck2Id);
     }
 
-    /**
-     * Asserts that both players still own the deck they started with, and that neither is
-     * holding a deck on behalf of a game.
-     */
+    /** Asserts that both players still own the deck they started with. */
     private void assertDeckUndisturbed(String deck1Id, String deck2Id) {
         Player stored1 = playerRepository.findById(player1.getId()).orElseThrow();
         Player stored2 = playerRepository.findById(player2.getId()).orElseThrow();
 
         assertEquals(deck1Id, stored1.getCurrentDeck().getId());
         assertEquals(deck2Id, stored2.getCurrentDeck().getId());
-        assertNull(stored1.getOriginalDeck());
-        assertNull(stored2.getOriginalDeck());
     }
 
     @Test

--- a/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
@@ -87,6 +87,13 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
         deck2.setCards(testCards2);
         deck2.setRemainingCards(DECK_SIZE);
         deck2 = deckRepository.save(deck2);
+
+        // A real player owns the deck they play with, and the tests below check that a
+        // game leaves that ownership alone.
+        player1.setCurrentDeck(deck1);
+        player1 = playerRepository.save(player1);
+        player2.setCurrentDeck(deck2);
+        player2 = playerRepository.save(player2);
     }
 
     private List<Card> createTestCards(String prefix) {
@@ -342,15 +349,10 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
         // Initialize and play a game
         GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
 
-        // Verify that during game, players have temporary decks
-        Player gamePlayer1 = playerRepository.findById(player1.getId()).orElseThrow();
-        Player gamePlayer2 = playerRepository.findById(player2.getId()).orElseThrow();
-        
-        // During game, currentDeck should be temporary, originalDeck should reference original
-        assertNotEquals(originalDeck1Id, gamePlayer1.getCurrentDeck().getId()); // Temporary deck has different ID
-        assertNotEquals(originalDeck2Id, gamePlayer2.getCurrentDeck().getId()); // Temporary deck has different ID
-        assertEquals(originalDeck1Id, gamePlayer1.getOriginalDeck().getId()); // Original deck stored
-        assertEquals(originalDeck2Id, gamePlayer2.getOriginalDeck().getId()); // Original deck stored
+        // A game in progress does not borrow the deck. It used to copy it into a temporary
+        // deck, write that over currentDeck and park the real one in originalDeck, which
+        // left a player mid-game pointing at a deck document that was never saved.
+        assertDeckUndisturbed(originalDeck1Id, originalDeck2Id);
 
         // Play some moves to modify game state
         CardDto cardDto1 = game.getCurrentPlayerHand().get(0);
@@ -391,22 +393,32 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
             assertEquals(originalDeck2Cards.get(i).getId(), storedDeck2.getCards().get(i).getId());
             assertEquals(originalDeck2Cards.get(i).getPower(), storedDeck2.getCards().get(i).getPower());
         }
+
+        assertDeckUndisturbed(originalDeck1Id, originalDeck2Id);
     }
 
-    @Test 
-    void testDeckRestorationAfterGameCompletion() {
+    /**
+     * Asserts that both players still own the deck they started with, and that neither is
+     * holding a deck on behalf of a game.
+     */
+    private void assertDeckUndisturbed(String deck1Id, String deck2Id) {
+        Player stored1 = playerRepository.findById(player1.getId()).orElseThrow();
+        Player stored2 = playerRepository.findById(player2.getId()).orElseThrow();
+
+        assertEquals(deck1Id, stored1.getCurrentDeck().getId());
+        assertEquals(deck2Id, stored2.getCurrentDeck().getId());
+        assertNull(stored1.getOriginalDeck());
+        assertNull(stored2.getOriginalDeck());
+    }
+
+    @Test
+    void testDeckSurvivesACompletedGame() {
         // Store original deck references
         String originalDeck1Id = deck1.getId();
         String originalDeck2Id = deck2.getId();
 
         // Initialize game
         GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
-
-        // Verify players have temporary decks during game
-        Player player1InGame = playerRepository.findById(player1.getId()).orElseThrow();
-        assertNotNull(player1InGame.getOriginalDeck());
-        assertEquals(originalDeck1Id, player1InGame.getOriginalDeck().getId());
-        assertNotEquals(originalDeck1Id, player1InGame.getCurrentDeck().getId());
 
         // Play enough moves to fill the board and complete the game
         // This is a simple way to trigger game completion
@@ -463,32 +475,15 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
             }
         }
 
-        // If game didn't complete naturally, that's OK for this test
-        // The important thing is to verify deck handling during active gameplay
-        
-        // Verify that regardless of game state, original decks are preserved
+        // Whether or not the game reached the end of the board, the decks are untouched.
+        // There is no restoration step to get wrong any more, and no state to lose if the
+        // game never finishes: the same assertion holds either way.
         Deck storedDeck1 = deckRepository.findById(originalDeck1Id).orElseThrow();
         Deck storedDeck2 = deckRepository.findById(originalDeck2Id).orElseThrow();
 
-        assertEquals(DECK_SIZE, storedDeck1.getCards().size()); // Original deck intact
-        assertEquals(DECK_SIZE, storedDeck2.getCards().size()); // Original deck intact
-        
-        // Verify that players still have their originalDeck references during active games
-        Player player1Final = playerRepository.findById(player1.getId()).orElseThrow();
-        Player player2Final = playerRepository.findById(player2.getId()).orElseThrow();
-        
-        if (game.getState() == GameState.IN_PROGRESS) {
-            // Game still active - should have originalDeck references
-            assertNotNull(player1Final.getOriginalDeck());
-            assertNotNull(player2Final.getOriginalDeck());
-            assertEquals(originalDeck1Id, player1Final.getOriginalDeck().getId());
-            assertEquals(originalDeck2Id, player2Final.getOriginalDeck().getId());
-        } else if (game.getState() == GameState.COMPLETED) {
-            // Game completed - original decks should be restored
-            assertEquals(originalDeck1Id, player1Final.getCurrentDeck().getId());
-            assertEquals(originalDeck2Id, player2Final.getCurrentDeck().getId());
-            assertNull(player1Final.getOriginalDeck()); // Cleaned up
-            assertNull(player2Final.getOriginalDeck()); // Cleaned up
-        }
+        assertEquals(DECK_SIZE, storedDeck1.getCards().size());
+        assertEquals(DECK_SIZE, storedDeck2.getCards().size());
+
+        assertDeckUndisturbed(originalDeck1Id, originalDeck2Id);
     }
 }

--- a/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
+++ b/backend/src/test/java/com/cardgame/GameFlowIntegrationTest.java
@@ -11,7 +11,6 @@ import com.cardgame.service.GameService;
 import com.cardgame.support.IntegrationTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
@@ -155,34 +154,30 @@ class GameFlowIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @Disabled("Adjacency validation needs investigation - move being allowed when it shouldn't be")
     void testInvalidCardPlacement_NotAdjacent() {
         GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
 
-        // Player 1 tries to place card in non-adjacent position
+        // Player 1's only card on the board is the one placed at (1,3) during
+        // initialization. (0,0) is orthogonally adjacent to (0,1) and (1,0), and neither
+        // holds a card of theirs.
         CardDto cardToPlace = game.getCurrentPlayerHand().get(0);
         Card card = new Card(cardToPlace.getId(), cardToPlace.getPower(), cardToPlace.getName());
         PlayerAction action = ImmutablePlayerAction.builder()
                 .type(PlayerAction.ActionType.PLACE_CARD)
                 .playerId(player1.getId())
                 .card(card)
-                .targetPosition(new Position(0, 0)) // Not adjacent to (2,4)
+                .targetPosition(new Position(0, 0))
                 .timestamp(System.currentTimeMillis())
                 .build();
 
-        // Should throw exception (could be InvalidMoveException or IllegalArgumentException)
-        try {
-            GameDto result = gameService.processMove(game.getId(), action);
-            // If we get here, the move was allowed when it shouldn't be
-            System.out.println("DEBUG: Move was allowed! Board state:");
-            System.out.println("Board pieces: " + result.getBoard().getPieces());
-            System.out.println("Current player: " + result.getCurrentPlayerId());
-            fail("Expected exception to be thrown for non-adjacent card placement, but move was allowed");
-        } catch (Exception e) {
-            // This is expected - the move should fail
-            System.out.println("DEBUG: Exception correctly thrown: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            assertTrue(true, "Exception correctly thrown: " + e.getMessage());
-        }
+        // Name the reason as well as the refusal. Every other way this move could fail —
+        // an unknown card, an occupied position, the wrong turn — also throws
+        // InvalidMoveException, so a test that only asserts "something was thrown" would
+        // keep passing after adjacency had stopped being checked at all.
+        InvalidMoveException thrown = assertThrows(InvalidMoveException.class,
+                () -> gameService.processMove(game.getId(), action));
+        assertTrue(thrown.getMessage().contains("adjacent"),
+                "Expected the move to be refused for adjacency, but got: " + thrown.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/cardgame/OnlineGameBackendTest.java
+++ b/backend/src/test/java/com/cardgame/OnlineGameBackendTest.java
@@ -107,6 +107,30 @@ public class OnlineGameBackendTest extends IntegrationTestBase {
     }
 
     @Test
+    public void testHostCannotJoinTheirOwnMatch() throws Exception {
+        MatchResponse created = readMatch(createMatchAs(HOST_SUPABASE_ID));
+
+        MvcResult result = mockMvc.perform(post("/api/online-game/join/" + created.getMatchId())
+                        .header(HttpHeaders.AUTHORIZATION, TestJwtSupport.bearerFor(HOST_SUPABASE_ID))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andReturn();
+        if (result.getRequest().isAsyncStarted()) {
+            result.getAsyncResult();
+            result = mockMvc.perform(asyncDispatch(result)).andReturn();
+        }
+
+        assertEquals(400, result.getResponse().getStatus());
+        assertTrue(result.getResponse().getContentAsString().contains("Cannot join your own match"),
+                "Expected the refusal to name the reason, but got: "
+                        + result.getResponse().getContentAsString());
+
+        // The match the host created is still theirs to be joined by somebody else.
+        MatchResponse joined = readMatch(joinMatchAs(GUEST_SUPABASE_ID, created.getMatchId()));
+        assertEquals("IN_PROGRESS", joined.getStatus());
+    }
+
+    @Test
     public void testAnonymousCallerCannotCreateAMatch() throws Exception {
         mockMvc.perform(post("/api/online-game/create")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/cardgame/integration/VariedCardPowersTest.java
+++ b/backend/src/test/java/com/cardgame/integration/VariedCardPowersTest.java
@@ -302,19 +302,11 @@ public class VariedCardPowersTest extends IntegrationTestBase {
             
             // Get the game model to check what cards were placed
             GameModel gameModel = gameRepository.findById(game.getId()).orElseThrow();
-            
-            // Check board positions (1,3) and (1,1) for placed cards
-            String cardId1 = gameModel.getBoard().getPieces().get("1,3");
-            String cardId2 = gameModel.getBoard().getPieces().get("1,1");
-            
-            // Get the placed cards from players
-            Player updatedP1 = playerRepository.findById(p1.getId()).orElseThrow();
-            Player updatedP2 = playerRepository.findById(p2.getId()).orElseThrow();
-            
-            // Count the powers of placed cards
-            updatedP1.getPlacedCards().values().forEach(card -> 
+
+            // Count the powers of the opening cards, which the game itself now records
+            gameModel.placedCardsOf(p1.getId()).values().forEach(card ->
                 placementCounts.merge(card.getPower(), 1, Integer::sum));
-            updatedP2.getPlacedCards().values().forEach(card -> 
+            gameModel.placedCardsOf(p2.getId()).values().forEach(card ->
                 placementCounts.merge(card.getPower(), 1, Integer::sum));
         }
         

--- a/backend/src/test/java/com/cardgame/security/ApiSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/cardgame/security/ApiSecurityIntegrationTest.java
@@ -106,10 +106,9 @@ class ApiSecurityIntegrationTest extends IntegrationTestBase {
     @Test
     @DisplayName("a player cannot read somebody else's record")
     void refusesReadingAnotherPlayer() throws Exception {
+        // The hand endpoint that used to be checked here as well is gone: a hand belongs
+        // to a game, not to a player, so there is nothing for it to answer with.
         mockMvc.perform(get("/players/" + bobPlayerId).header(HttpHeaders.AUTHORIZATION, bearer(ALICE_SUPABASE_ID)))
-                .andExpect(status().isForbidden());
-        mockMvc.perform(get("/players/game/players/" + bobPlayerId + "/hand")
-                        .header(HttpHeaders.AUTHORIZATION, bearer(ALICE_SUPABASE_ID)))
                 .andExpect(status().isForbidden());
 
         mockMvc.perform(get("/players/" + alicePlayerId).header(HttpHeaders.AUTHORIZATION, bearer(ALICE_SUPABASE_ID)))

--- a/backend/src/test/java/com/cardgame/service/ColumnScoringTest.java
+++ b/backend/src/test/java/com/cardgame/service/ColumnScoringTest.java
@@ -1,51 +1,28 @@
 package com.cardgame.service;
 
 import com.cardgame.model.*;
-import com.cardgame.dto.ColumnScoreDto;
-import com.cardgame.dto.GameDto;
-import com.cardgame.service.player.PlayerService;
 import com.cardgame.service.util.ScoreCalculator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
+/**
+ * Scoring is a function of the game and nothing else, so this needs no Spring context,
+ * no database and no mock. It used to mock PlayerService, because the cards a player had
+ * on the board were on their player document.
+ */
 class ColumnScoringTest {
 
-    @Mock
-    private PlayerService playerService;
-
     private GameModel gameModel;
-    private Player player1;
-    private Player player2;
     private String player1Id = "player1";
     private String player2Id = "player2";
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-        
-        // Initialize players
-        player1 = new Player();
-        player1.setId(player1Id);
-        player1.setName("Player 1");
-        player1.setPlacedCards(new HashMap<>());
-        
-        player2 = new Player();
-        player2.setId(player2Id);
-        player2.setName("Player 2");
-        player2.setPlacedCards(new HashMap<>());
-        
-        // Mock player service
-        when(playerService.getPlayer(player1Id)).thenReturn(player1);
-        when(playerService.getPlayer(player2Id)).thenReturn(player2);
-        
         // Initialize game model
         gameModel = new GameModel();
         gameModel.setId("test-game-id");
@@ -64,7 +41,7 @@ class ColumnScoringTest {
     @DisplayName("Test empty board returns zero scores for all columns")
     void testEmptyBoard() {
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         assertEquals(3, columnScores.size());
         
@@ -82,12 +59,11 @@ class ColumnScoringTest {
     @DisplayName("Test single card in column gives that player the column")
     void testSingleCardWinsColumn() {
         // Place a card with power 5 for player1 in column 0
-        Card card1 = new Card("card1", 5, "Test Card");
-        player1.getPlacedCards().put("0,0", card1);
-        gameModel.getBoard().getPieces().put("0,0", "card1");
-        
+        placeCard(player1Id, "0,0", new Card("card1", 5, "Test Card"));
+
+
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         // Column 0: Player1 should win with 5 points
         ScoreCalculator.ColumnScore col0 = columnScores.get(0);
@@ -110,25 +86,16 @@ class ColumnScoringTest {
     @DisplayName("Test multiple cards in same column are summed correctly")
     void testMultipleCardsInColumn() {
         // Player1 cards in column 1
-        Card card1 = new Card("card1", 3, "Card 1");
-        Card card2 = new Card("card2", 4, "Card 2");
-        player1.getPlacedCards().put("1,0", card1);
-        player1.getPlacedCards().put("1,1", card2);
-        
+        placeCard(player1Id, "1,0", new Card("card1", 3, "Card 1"));
+        placeCard(player1Id, "1,1", new Card("card2", 4, "Card 2"));
+
         // Player2 cards in column 1
-        Card card3 = new Card("card3", 5, "Card 3");
-        Card card4 = new Card("card4", 2, "Card 4");
-        player2.getPlacedCards().put("1,2", card3);
-        player2.getPlacedCards().put("1,3", card4);
-        
-        // Update board
-        gameModel.getBoard().getPieces().put("1,0", "card1");
-        gameModel.getBoard().getPieces().put("1,1", "card2");
-        gameModel.getBoard().getPieces().put("1,2", "card3");
-        gameModel.getBoard().getPieces().put("1,3", "card4");
-        
+        placeCard(player2Id, "1,2", new Card("card3", 5, "Card 3"));
+        placeCard(player2Id, "1,3", new Card("card4", 2, "Card 4"));
+
+
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         // Column 1: Player1 has 3+4=7, Player2 has 5+2=7, should be a tie
         ScoreCalculator.ColumnScore col1 = columnScores.get(1);
@@ -142,20 +109,20 @@ class ColumnScoringTest {
     @DisplayName("Test player wins with 2 out of 3 columns")
     void testPlayerWinsWith2Columns() {
         // Column 0: Player1 wins (5 vs 3)
-        placeCard(player1, "0,0", new Card("card1", 5, "Card 1"));
-        placeCard(player2, "0,1", new Card("card2", 3, "Card 2"));
+        placeCard(player1Id, "0,0", new Card("card1", 5, "Card 1"));
+        placeCard(player2Id, "0,1", new Card("card2", 3, "Card 2"));
         
         // Column 1: Player2 wins (2 vs 6)
-        placeCard(player1, "1,0", new Card("card3", 2, "Card 3"));
-        placeCard(player2, "1,1", new Card("card4", 6, "Card 4"));
+        placeCard(player1Id, "1,0", new Card("card3", 2, "Card 3"));
+        placeCard(player2Id, "1,1", new Card("card4", 6, "Card 4"));
         
         // Column 2: Player1 wins (8 vs 7)
-        placeCard(player1, "2,0", new Card("card5", 8, "Card 5"));
-        placeCard(player2, "2,1", new Card("card6", 7, "Card 6"));
+        placeCard(player1Id, "2,0", new Card("card5", 8, "Card 5"));
+        placeCard(player2Id, "2,1", new Card("card6", 7, "Card 6"));
         
         // Calculate column scores
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         // Verify column winners
         assertEquals(player1Id, columnScores.get(0).winnerId);
@@ -163,7 +130,7 @@ class ColumnScoringTest {
         assertEquals(player1Id, columnScores.get(2).winnerId);
         
         // Determine overall winner
-        String winner = ScoreCalculator.determineWinner(gameModel, playerService);
+        String winner = ScoreCalculator.determineWinner(gameModel);
         assertEquals(player1Id, winner);
         
         // Check that scores were updated (columns won)
@@ -176,15 +143,15 @@ class ColumnScoringTest {
     @DisplayName("Test game ends in tie when players win equal columns")
     void testGameTieWithEqualColumns() {
         // Column 0: Player1 wins
-        placeCard(player1, "0,0", new Card("card1", 5, "Card 1"));
+        placeCard(player1Id, "0,0", new Card("card1", 5, "Card 1"));
         
         // Column 1: Player2 wins
-        placeCard(player2, "1,0", new Card("card2", 5, "Card 2"));
+        placeCard(player2Id, "1,0", new Card("card2", 5, "Card 2"));
         
         // Column 2: Tie (both have 0)
         // No cards placed
         
-        String winner = ScoreCalculator.determineWinner(gameModel, playerService);
+        String winner = ScoreCalculator.determineWinner(gameModel);
         assertNull(winner); // null indicates tie
         
         // Both players should have 1 column won
@@ -196,12 +163,12 @@ class ColumnScoringTest {
     @DisplayName("Test final column scores are stored when game completes")
     void testFinalColumnScoresStored() {
         // Setup a simple game state
-        placeCard(player1, "0,0", new Card("card1", 5, "Card 1"));
-        placeCard(player2, "1,0", new Card("card2", 3, "Card 2"));
+        placeCard(player1Id, "0,0", new Card("card1", 5, "Card 1"));
+        placeCard(player2Id, "1,0", new Card("card2", 3, "Card 2"));
         
         // Simulate game completion
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         // Convert to the format stored in GameModel
         Map<Integer, Map<String, Integer>> finalColumnScores = new HashMap<>();
@@ -231,13 +198,13 @@ class ColumnScoringTest {
     @DisplayName("Test column with all same power results in tie")
     void testColumnTieWithSamePower() {
         // Both players have total power 10 in column 0
-        placeCard(player1, "0,0", new Card("card1", 4, "Card 1"));
-        placeCard(player1, "0,1", new Card("card2", 6, "Card 2"));
-        placeCard(player2, "0,2", new Card("card3", 7, "Card 3"));
-        placeCard(player2, "0,3", new Card("card4", 3, "Card 4"));
+        placeCard(player1Id, "0,0", new Card("card1", 4, "Card 1"));
+        placeCard(player1Id, "0,1", new Card("card2", 6, "Card 2"));
+        placeCard(player2Id, "0,2", new Card("card3", 7, "Card 3"));
+        placeCard(player2Id, "0,3", new Card("card4", 3, "Card 4"));
         
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         ScoreCalculator.ColumnScore col0 = columnScores.get(0);
         assertEquals(10, col0.playerScores.get(player1Id));
@@ -253,11 +220,11 @@ class ColumnScoringTest {
         for (int col = 0; col < 3; col++) {
             Card card1 = new Card("card" + (col*2), 5, "Card " + (col*2));
             Card card2 = new Card("card" + (col*2+1), 5, "Card " + (col*2+1));
-            placeCard(player1, col + ",0", card1);
-            placeCard(player2, col + ",1", card2);
+            placeCard(player1Id, col + ",0", card1);
+            placeCard(player2Id, col + ",1", card2);
         }
         
-        String winner = ScoreCalculator.determineWinner(gameModel, playerService);
+        String winner = ScoreCalculator.determineWinner(gameModel);
         assertNull(winner); // Game is a tie
         
         // Both players should have 0 columns won (all tied)
@@ -269,18 +236,18 @@ class ColumnScoringTest {
     @DisplayName("Test complex board state with mixed columns")
     void testComplexBoardState() {
         // Column 0: Heavy battle, Player1 wins 15 vs 14
-        placeCard(player1, "0,0", new Card("c1", 7, "Card 1"));
-        placeCard(player1, "0,1", new Card("c2", 8, "Card 2"));
-        placeCard(player2, "0,2", new Card("c3", 9, "Card 3"));
-        placeCard(player2, "0,3", new Card("c4", 5, "Card 4"));
+        placeCard(player1Id, "0,0", new Card("c1", 7, "Card 1"));
+        placeCard(player1Id, "0,1", new Card("c2", 8, "Card 2"));
+        placeCard(player2Id, "0,2", new Card("c3", 9, "Card 3"));
+        placeCard(player2Id, "0,3", new Card("c4", 5, "Card 4"));
         
         // Column 1: Empty
         
         // Column 2: Single card from Player2
-        placeCard(player2, "2,0", new Card("c5", 3, "Card 5"));
+        placeCard(player2Id, "2,0", new Card("c5", 3, "Card 5"));
         
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = 
-            ScoreCalculator.calculateColumnScores(gameModel, playerService);
+            ScoreCalculator.calculateColumnScores(gameModel);
         
         // Verify results
         assertEquals(player1Id, columnScores.get(0).winnerId);
@@ -288,13 +255,12 @@ class ColumnScoringTest {
         assertEquals(player2Id, columnScores.get(2).winnerId);
         
         // Game should be tied (1-1 columns, with 1 empty)
-        String winner = ScoreCalculator.determineWinner(gameModel, playerService);
+        String winner = ScoreCalculator.determineWinner(gameModel);
         assertNull(winner);
     }
 
     // Helper method to place a card on the board
-    private void placeCard(Player player, String position, Card card) {
-        player.getPlacedCards().put(position, card);
-        gameModel.getBoard().getPieces().put(position, card.getId());
+    private void placeCard(String playerId, String position, Card card) {
+        gameModel.playCard(playerId, Position.fromStorageString(position), card);
     }
 }

--- a/backend/src/test/java/com/cardgame/service/GameLogicIntegrationTest.java
+++ b/backend/src/test/java/com/cardgame/service/GameLogicIntegrationTest.java
@@ -136,22 +136,25 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         testCard.setPower(5);
         cardRepository.save(testCard);
 
-        Player player1 = playerRepository.findById(player1Id).orElseThrow();
-        player1.getHand().add(testCard);
-        playerRepository.save(player1);
-
         gameModel = new GameModel();
         gameModel.setId("test_game_validator");
         gameModel.setGameState(GameState.IN_PROGRESS);
         gameModel.setPlayerIds(Arrays.asList(player1Id, player2Id));
         gameModel.setCurrentPlayerId(player1Id);
+        gameModel.setBoard(new Board());
 
-        Board board = new Board();
-        board.placeCard(new Position(1, 2), "validator_card");
-        gameModel.setBoard(board);
+        gameModel.seatPlayer(player1Id, "Player 1", List.of(testCard));
+        gameModel.seatPlayer(player2Id, "Player 2", List.of());
+        gameModel.playCard(player1Id, new Position(1, 2), new Card("validator_card", 1, "Validator Card"));
+    }
 
-        player1.getPlacedCards().put("1,2", new Card("validator_card", 1, "Validator Card"));
-        playerRepository.save(player1);
+    /**
+     * The cards a player has on the board, for tests that build a position directly rather
+     * than by playing into it. Reading through the game is deliberately non-creating, so
+     * writing needs a way in.
+     */
+    private Map<String, Card> placedCardsFor(String playerId) {
+        return gameModel.getPlacedCards().computeIfAbsent(playerId, id -> new HashMap<>());
     }
 
     @Nested
@@ -229,8 +232,7 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("Invalid move - wrong player turn")
         void testInvalidMove_WrongPlayerTurn() {
-            Player player2 = playerRepository.findById(player2Id).orElseThrow();
-            Card card = player2.getHand().get(0);
+            Card card = gameRepository.findById(game.getId()).orElseThrow().handOf(player2Id).get(0);
             PlayerAction action = createPlaceCardAction(player2Id,
                     ImmutableCardDto.builder()
                             .id(card.getId())
@@ -322,10 +324,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("Valid orthogonal chain building")
         void testValidMove_OrthogonalChain() {
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().put("1,1", new Card("chain_card", 2, "Chain Card"));
+            placedCardsFor(player1Id).put("1,1", new Card("chain_card", 2, "Chain Card"));
             gameModel.getBoard().placeCard(new Position(1, 1), "chain_card");
-            playerRepository.save(player1);
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(1, 0));
 
@@ -341,10 +341,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("Invalid diagonal placement from chain")
         void testInvalidMove_DiagonalFromChain() {
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().put("1,1", new Card("chain_card", 2, "Chain Card"));
+            placedCardsFor(player1Id).put("1,1", new Card("chain_card", 2, "Chain Card"));
             gameModel.getBoard().placeCard(new Position(1, 1), "chain_card");
-            playerRepository.save(player1);
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(0, 0));
 
@@ -361,10 +359,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("Valid placement when adjacent to both own and opponent cards")
         void testValidMove_AdjacentToBothPlayers() {
-            Player player2 = playerRepository.findById(player2Id).orElseThrow();
-            player2.getPlacedCards().put("0,2", new Card("opponent_card", 3, "Opponent Card"));
+            placedCardsFor(player2Id).put("0,2", new Card("opponent_card", 3, "Opponent Card"));
             gameModel.getBoard().placeCard(new Position(0, 2), "opponent_card");
-            playerRepository.save(player2);
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(1, 1));
 
@@ -380,10 +376,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @Test
         @DisplayName("Invalid placement adjacent only to opponent")
         void testInvalidMove_AdjacentOnlyToOpponent() {
-            Player player2 = playerRepository.findById(player2Id).orElseThrow();
-            player2.getPlacedCards().put("0,1", new Card("opponent_card", 3, "Opponent Card"));
+            placedCardsFor(player2Id).put("0,1", new Card("opponent_card", 3, "Opponent Card"));
             gameModel.getBoard().placeCard(new Position(0, 1), "opponent_card");
-            playerRepository.save(player2);
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(0, 0));
 
@@ -402,10 +396,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         void testValidMove_BoardBoundaries() {
             gameModel.getBoard().getPieces().clear();
             gameModel.getBoard().placeCard(new Position(0, 0), "edge_card");
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
-            player1.getPlacedCards().put("0,0", new Card("edge_card", 1, "Edge Card"));
-            playerRepository.save(player1);
+            placedCardsFor(player1Id).clear();
+            placedCardsFor(player1Id).put("0,0", new Card("edge_card", 1, "Edge Card"));
 
             PlayerAction eastAction = createValidatorPlaceCardAction(player1Id, new Position(1, 0));
             assertDoesNotThrow(() -> gameValidator.validateMove(gameModel, eastAction),
@@ -429,11 +421,9 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
             gameModel.getBoard().placeCard(new Position(0, 0), "card1");
             gameModel.getBoard().placeCard(new Position(1, 1), "card2");
 
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
-            player1.getPlacedCards().put("0,0", new Card("card1", 1, "Card 1"));
-            player1.getPlacedCards().put("1,1", new Card("card2", 2, "Card 2"));
-            playerRepository.save(player1);
+            placedCardsFor(player1Id).clear();
+            placedCardsFor(player1Id).put("0,0", new Card("card1", 1, "Card 1"));
+            placedCardsFor(player1Id).put("1,1", new Card("card2", 2, "Card 2"));
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(2, 2));
 
@@ -587,10 +577,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
             gameModel.getBoard().getPieces().clear();
             gameModel.getBoard().placeCard(new Position(ownCardX, ownCardY), "test_own_card");
 
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
-            player1.getPlacedCards().put(ownCardX + "," + ownCardY, new Card("test_own_card", 1, "Test Own Card"));
-            playerRepository.save(player1);
+            placedCardsFor(player1Id).clear();
+            placedCardsFor(player1Id).put(ownCardX + "," + ownCardY, new Card("test_own_card", 1, "Test Own Card"));
 
             PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(targetX, targetY));
 
@@ -621,10 +609,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
             gameModel.getBoard().getPieces().clear();
             gameModel.getBoard().placeCard(new Position(sourceX, sourceY), "source_card");
 
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
-            player1.getPlacedCards().put(sourceX + "," + sourceY, new Card("source_card", 1, "Source Card"));
-            playerRepository.save(player1);
+            placedCardsFor(player1Id).clear();
+            placedCardsFor(player1Id).put(sourceX + "," + sourceY, new Card("source_card", 1, "Source Card"));
 
             int[][] orthogonalOffsets = {{0,1}, {0,-1}, {1,0}, {-1,0}};
 
@@ -688,15 +674,13 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         @DisplayName("Test chain building with multiple cards")
         void testChainBuilding(int chainLength) {
             gameModel.getBoard().getPieces().clear();
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
 
             for (int i = 0; i < Math.min(chainLength, 3); i++) {
                 String cardId = "chain_card_" + i;
                 gameModel.getBoard().placeCard(new Position(i, 2), cardId);
-                player1.getPlacedCards().put(i + ",2", new Card(cardId, 1, "Chain Card " + i));
+                placedCardsFor(player1Id).put(i + ",2", new Card(cardId, 1, "Chain Card " + i));
             }
-            playerRepository.save(player1);
 
             if (chainLength <= 3) {
                 PlayerAction action = createValidatorPlaceCardAction(player1Id, new Position(0, 1));
@@ -720,10 +704,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         void testNearlyFullBoardComplexOwnership() {
             // Clear board and create a complex checkerboard-like pattern
             gameModel.getBoard().getPieces().clear();
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            Player player2 = playerRepository.findById(player2Id).orElseThrow();
-            player1.getPlacedCards().clear();
-            player2.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
+            placedCardsFor(player2Id).clear();
 
             // Create checkerboard pattern (player1 on even sum coordinates, player2 on odd)
             int cardCounter = 0;
@@ -735,15 +717,13 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
                     gameModel.getBoard().placeCard(new Position(x, y), cardId);
 
                     if ((x + y) % 2 == 0) {
-                        player1.getPlacedCards().put(x + "," + y, new Card(cardId, 1, "P1 Card " + cardCounter));
+                        placedCardsFor(player1Id).put(x + "," + y, new Card(cardId, 1, "P1 Card " + cardCounter));
                     } else {
-                        player2.getPlacedCards().put(x + "," + y, new Card(cardId, 1, "P2 Card " + cardCounter));
+                        placedCardsFor(player2Id).put(x + "," + y, new Card(cardId, 1, "P2 Card " + cardCounter));
                     }
                     cardCounter++;
                 }
             }
-            playerRepository.save(player1);
-            playerRepository.save(player2);
 
             // Find empty positions and test adjacency rules
             List<Position> emptyPositions = gameModel.getBoard().getEmptyPositions();
@@ -761,7 +741,7 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
                     int adjY = emptyPos.getY() + offset[1];
                     String adjKey = adjX + "," + adjY;
 
-                    if (player1.getPlacedCards().containsKey(adjKey)) {
+                    if (placedCardsFor(player1Id).containsKey(adjKey)) {
                         hasAdjacentOwnCard = true;
                         break;
                     }
@@ -783,26 +763,24 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         void testMaximumChainLengthScenarios() {
             // Test maximum possible horizontal chain (3 cards)
             gameModel.getBoard().getPieces().clear();
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
 
             // Create maximum horizontal chain
             for (int x = 0; x < 3; x++) {
                 String cardId = "h_chain_" + x;
                 gameModel.getBoard().placeCard(new Position(x, 2), cardId);
-                player1.getPlacedCards().put(x + ",2", new Card(cardId, 1, "H Chain " + x));
+                placedCardsFor(player1Id).put(x + ",2", new Card(cardId, 1, "H Chain " + x));
             }
 
             // Test maximum vertical chain (5 cards)
             gameModel.getBoard().getPieces().clear();
-            player1.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
 
             for (int y = 0; y < 5; y++) {
                 String cardId = "v_chain_" + y;
                 gameModel.getBoard().placeCard(new Position(1, y), cardId);
-                player1.getPlacedCards().put("1," + y, new Card(cardId, 1, "V Chain " + y));
+                placedCardsFor(player1Id).put("1," + y, new Card(cardId, 1, "V Chain " + y));
             }
-            playerRepository.save(player1);
 
             // The board is three wide, so a full column of your own cards touches every
             // remaining cell. This previously asserted the opposite and only passed
@@ -822,22 +800,20 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         void testIsolatedCardGroups() {
             // Create two separate groups of player1 cards with no connection
             gameModel.getBoard().getPieces().clear();
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
 
             // Group 1: Top-left corner
             gameModel.getBoard().placeCard(new Position(0, 0), "group1_card1");
             gameModel.getBoard().placeCard(new Position(0, 1), "group1_card2");
-            player1.getPlacedCards().put("0,0", new Card("group1_card1", 1, "Group 1 Card 1"));
-            player1.getPlacedCards().put("0,1", new Card("group1_card2", 1, "Group 1 Card 2"));
+            placedCardsFor(player1Id).put("0,0", new Card("group1_card1", 1, "Group 1 Card 1"));
+            placedCardsFor(player1Id).put("0,1", new Card("group1_card2", 1, "Group 1 Card 2"));
 
             // Group 2: Bottom-right corner (separated by gaps)
             gameModel.getBoard().placeCard(new Position(2, 3), "group2_card1");
             gameModel.getBoard().placeCard(new Position(2, 4), "group2_card2");
-            player1.getPlacedCards().put("2,3", new Card("group2_card1", 1, "Group 2 Card 1"));
-            player1.getPlacedCards().put("2,4", new Card("group2_card2", 1, "Group 2 Card 2"));
+            placedCardsFor(player1Id).put("2,3", new Card("group2_card1", 1, "Group 2 Card 1"));
+            placedCardsFor(player1Id).put("2,4", new Card("group2_card2", 1, "Group 2 Card 2"));
 
-            playerRepository.save(player1);
 
             // Should be able to place adjacent to either group
             // Adjacent to group 1
@@ -862,8 +838,7 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
         void testPerformanceWithManyChecks() {
             // Create a scenario that requires checking many positions
             gameModel.getBoard().getPieces().clear();
-            Player player1 = playerRepository.findById(player1Id).orElseThrow();
-            player1.getPlacedCards().clear();
+            placedCardsFor(player1Id).clear();
 
             // Place cards in a specific pattern that maximizes adjacency calculations
             int[][] positions = {{0,0}, {0,2}, {0,4}, {2,0}, {2,2}, {2,4}};
@@ -871,9 +846,8 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
                 String cardId = "perf_card_" + i;
                 Position pos = new Position(positions[i][0], positions[i][1]);
                 gameModel.getBoard().placeCard(pos, cardId);
-                player1.getPlacedCards().put(pos.toStorageString(), new Card(cardId, 1, "Perf Card " + i));
+                placedCardsFor(player1Id).put(pos.toStorageString(), new Card(cardId, 1, "Perf Card " + i));
             }
-            playerRepository.save(player1);
 
             // Test performance by validating moves at all remaining positions
             long startTime = System.currentTimeMillis();
@@ -921,13 +895,11 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
             for (Position corner : corners) {
                 // Clear board and place card at corner
                 gameModel.getBoard().getPieces().clear();
-                Player player1 = playerRepository.findById(player1Id).orElseThrow();
-                player1.getPlacedCards().clear();
+                placedCardsFor(player1Id).clear();
 
                 String cardId = "corner_card_" + corner.toStorageString();
                 gameModel.getBoard().placeCard(corner, cardId);
-                player1.getPlacedCards().put(corner.toStorageString(), new Card(cardId, 1, "Corner Card"));
-                playerRepository.save(player1);
+                placedCardsFor(player1Id).put(corner.toStorageString(), new Card(cardId, 1, "Corner Card"));
 
                 // Test all orthogonal positions from corner
                 int[][] orthogonalOffsets = {{0,1}, {0,-1}, {1,0}, {-1,0}};
@@ -964,13 +936,11 @@ class GameLogicIntegrationTest extends IntegrationTestBase {
 
             for (Position edge : edges) {
                 gameModel.getBoard().getPieces().clear();
-                Player player1 = playerRepository.findById(player1Id).orElseThrow();
-                player1.getPlacedCards().clear();
+                placedCardsFor(player1Id).clear();
 
                 String cardId = "edge_card_" + edge.toStorageString();
                 gameModel.getBoard().placeCard(edge, cardId);
-                player1.getPlacedCards().put(edge.toStorageString(), new Card(cardId, 1, "Edge Card"));
-                playerRepository.save(player1);
+                placedCardsFor(player1Id).put(edge.toStorageString(), new Card(cardId, 1, "Edge Card"));
 
                 // Count valid orthogonal moves from edge
                 int validMoves = 0;

--- a/frontend/src/services/gameService.ts
+++ b/frontend/src/services/gameService.ts
@@ -203,16 +203,11 @@ class GameService {
             }
         }
         
-        // Fetch the current player's hand if not included in the response
-        let currentPlayerHand = backendData.currentPlayerHand || [];
-        
-        if (currentPlayerHand.length === 0 && currentPlayerId) {
-            try {
-                currentPlayerHand = await playerService.getPlayerHand(currentPlayerId);
-            } catch (error) {
-                console.error('Failed to fetch player hand:', error);
-            }
-        }
+        // A hand belongs to a game, and the game state carries it. There used to be a
+        // fallback here that asked the player endpoint for "the" hand, which only made
+        // sense while a player could be in one game at a time; an empty hand is now just
+        // a player who has played all their cards.
+        const currentPlayerHand = backendData.currentPlayerHand || [];
         
         return {
             id: backendData.id,

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,11 +1,8 @@
-import {Card} from "@/types/game";
 import {apiFetch} from "@/lib/apiClient";
 
 export interface PlayerDto {
     id: string;
     name: string;
-    score: number;
-    handSize: number;
     lifetimeScore: number;
     playerCardCounts: Record<string, number>;
     currentDeck?: {  // Make this optional since it's not in the DTO
@@ -46,20 +43,6 @@ class PlayerService {
             return await response.json();
         } catch (error) {
             throw new Error(`Error fetching player: ${error instanceof Error ? error.message : String(error)}`);
-        }
-    }
-
-    async getPlayerHand(playerId: string): Promise<Array<Card>> {
-        try {
-            const response = await apiFetch(`/game/players/${playerId}/hand`);
-
-            if (!response.ok) {
-                throw new Error('Failed to fetch player hand');
-            }
-
-            return await response.json();
-        } catch (error) {
-            throw new Error(`Error fetching player hand: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 

--- a/infra/migrations/2026-08-17-game-owned-state.js
+++ b/infra/migrations/2026-08-17-game-owned-state.js
@@ -1,0 +1,72 @@
+// Migrate documents written before game state moved onto the game.
+//
+//   mongosh "$MONGODB_URI" --file infra/migrations/2026-08-17-game-owned-state.js
+//
+// Take a backup first. Run it against the same database the backend reads; the URI in
+// SSM under /hand-of-fate/mongodb-uri already names it.
+//
+// Idempotent: running it twice does nothing the second time.
+//
+// What it does, and why each part is what it is — the shape of the data was checked
+// against production on 2026-08-17 before this was written, and it is small enough that
+// every case below is a real document rather than a hypothetical one.
+//
+//   1. Games that predate the change carry no hands and no placed cards of their own.
+//      Those live on the players, and the cards on the board are per-deck instances
+//      (spark_<uuid>) that appear in no catalogue, so a game whose players are gone has
+//      lost the power of every card on its board and can never be rendered again. There
+//      is no state to migrate them to. They are deleted.
+//
+//   2. currentDeck on a player mid-game points at a temporary deck that was never saved.
+//      The real one is parked in original_deck. Put it back before dropping the field,
+//      or the player is left owning a deck document that does not exist.
+//
+//   3. hand, score and placed_cards are no longer read or written by anything.
+
+const summary = { gamesDeleted: 0, decksDeleted: 0, decksRestored: 0, playersCleaned: 0 };
+
+// --- 1. games -------------------------------------------------------------------------
+// Only games that predate the change: one written by the new code has a `hands` field.
+const staleGames = db.games.find({ hands: { $exists: false } }, { _id: 1 }).toArray();
+if (staleGames.length > 0) {
+  const ids = staleGames.map((g) => g._id);
+  print(`Deleting ${ids.length} game(s) written before game-owned state: ${ids.join(', ')}`);
+  summary.gamesDeleted = db.games.deleteMany({ _id: { $in: ids } }).deletedCount;
+}
+
+// --- 2. restore the real deck ---------------------------------------------------------
+const borrowed = db.players.find({ original_deck: { $exists: true, $ne: null } }).toArray();
+borrowed.forEach((p) => {
+  print(`Restoring ${p.name}'s deck from original_deck`);
+  db.players.updateOne({ _id: p._id }, { $set: { currentDeck: p.original_deck } });
+  summary.decksRestored += 1;
+});
+
+// --- 3. drop the fields the game now owns ---------------------------------------------
+summary.playersCleaned = db.players.updateMany(
+  {
+    $or: [
+      { hand: { $exists: true } },
+      { score: { $exists: true } },
+      { placed_cards: { $exists: true } },
+      { original_deck: { $exists: true } },
+    ],
+  },
+  { $unset: { hand: '', score: '', placed_cards: '', original_deck: '' } }
+).modifiedCount;
+
+// --- 4. decks nobody owns -------------------------------------------------------------
+// Left behind by players that were deleted. Unrelated to this change in cause, but the
+// deck collection is read by deck ownership checks and these can never match anybody.
+const playerIds = db.players.find({}, { _id: 1 }).toArray().map((p) => String(p._id));
+const orphanedDecks = db.deck
+  .find({ ownerId: { $nin: playerIds } }, { _id: 1, ownerId: 1 })
+  .toArray();
+if (orphanedDecks.length > 0) {
+  print(`Deleting ${orphanedDecks.length} deck(s) whose owner no longer exists`);
+  summary.decksDeleted = db.deck.deleteMany({
+    _id: { $in: orphanedDecks.map((d) => d._id) },
+  }).deletedCount;
+}
+
+printjson(summary);


### PR DESCRIPTION
`Player` carried `hand`, `score`, `placed_cards` and `original_deck`, so a player could only be in one game at a time and a move wrote three documents to change one. They now live on `GameModel`, keyed by player id.

### Measured, same machine and harness, before and after

Counted with MongoDB's profiler rather than estimated:

| | before | after |
|---|---|---|
| database operations per move | 28.4 | 6.1 |
| of which player reads | 22.5 | 1.8 |
| p50 / p95 / p99 | 11 / 52 / 91 ms | 6 / 20–30 / 32–50 ms |
| RSS at 100 sockets | ~630 MiB | 520 MiB |

The old estimate in `CLAUDE.md` was "~10 round trips", which was too low. The dominant cost was `hasValidMoves` asking the validator about every empty square, with the validator reading the player each time.

In the load test `action` and `action→broadcast` are now the same number to a tenth of a millisecond. The gap between them was the price of rebuilding the view once per connected socket.

### Things found along the way

- **The temporary deck was deleted, not moved.** A deck is five cards and a hand is five cards, so the copy `setupPlayerGameState` made was empty from the moment it existed. What it did do was overwrite `currentDeck` with a deck that was never saved — which is why there is a player in production pointing at a deck document that does not exist, and why `NakamaMatchService` had two rounds of falling back to `original_deck` "due to lazy loading".
- **A player could join their own match.** `joinMatch` never checked. It survived because both seats shared one `Player` document; keyed by player id it would have been silently broken. Now refused, with a test.
- **The `@Disabled` adjacency test already passed.** The reason on it was stale — its own comment still described the opening card as sitting at a position it stopped being placed at. Re-enabled and tightened: it caught `Exception` and asserted nothing about it, so it would have kept passing after adjacency stopped being checked at all.
- `ColumnScoringTest` needed a mock `PlayerService` to describe cards on a board. Scoring is a function of the game now, so it needs no mock, no Spring context and no database.

### Deploying this

Order matters, because the migration sits in the middle:

1. Merge, and let Vercel deploy the frontend — it stops calling the hand endpoint the backend no longer has.
2. Take a fresh backup.
3. Build, push to ECR, deploy the stack.
4. Run `infra/migrations/2026-08-17-game-owned-state.js` **after** the deploy. Before it, the old code would write `hand` and `placed_cards` straight back onto the players at the start of the next game.

The migration was rehearsed against a dump of production: it deletes two games that are both junk (one has had both its players deleted and has been unrenderable for some time, the other is the self-match), repairs the dangling `currentDeck`, drops the dead fields, and clears four orphaned decks. Running it twice is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)