### PR TITLE
Optimistic locking on the move path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,15 @@ MongoDB. Production is a `t4g.small` sharing two vCPU with postgres, Nakama and
 cloudflared, so it has *less* CPU than this. The memory conclusion transfers,
 because the 768 MiB budget is the same; the latencies do not.
 
-**No concurrency control.** No `@Version` on documents, no transactions.
-Simultaneous writes overwrite each other.
+**~~No concurrency control.~~** `GameModel` carries `@Version`, and a move that loses
+the version check is retried once; a second failure sends the client the game as it
+actually stands and tells it to reload. Still no transactions, and deliberately so —
+a move is one document write, and MongoDB is atomic per document.
+
+`Player` and `Deck` are still unversioned. That is a smaller problem than it was:
+a game no longer writes to them, so the only writers left are registration, deck
+editing and the victory bonus at the end of a game, and none of those race with a
+move.
 
 **Nothing notices a wedged application.** The auto scaling group's health check is
 `EC2`, which sees a dead instance and nothing else. A backend that is running but
@@ -254,8 +261,10 @@ session is a judgement call that changes with what the project needs next.
    what is left is `@Version` for the read-modify-write race, not transactions.
    **That is the next session's work**; the working checklist is in the notes
    outside the repository.
-4. **Make matches survive a restart,** with optimistic locking. Either commit to
-   Nakama's match API or persist match state properly.
+4. **Make matches survive a restart.** Either commit to Nakama's match API or
+   persist match state properly. (Optimistic locking was the other half of this
+   item and is done; what is left is that `NakamaMatchService` keeps matches in a
+   `ConcurrentHashMap`, so a restart drops every active one.)
 
    Afterwards a projection becomes worth building, and only afterwards. The read
    side has one clean thing to project from now that the write model is a single

--- a/backend/src/main/java/com/cardgame/exception/game/ConcurrentMoveException.java
+++ b/backend/src/main/java/com/cardgame/exception/game/ConcurrentMoveException.java
@@ -1,0 +1,14 @@
+package com.cardgame.exception.game;
+
+/**
+ * A move could not be applied because the game kept changing underneath it.
+ *
+ * <p>Distinct from {@link InvalidMoveException}: the move was legal, and trying it again
+ * against fresh state may well succeed. The client is being told to resync rather than
+ * that it did something wrong.
+ */
+public class ConcurrentMoveException extends RuntimeException {
+    public ConcurrentMoveException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/cardgame/model/GameModel.java
+++ b/backend/src/main/java/com/cardgame/model/GameModel.java
@@ -1,6 +1,7 @@
 package com.cardgame.model;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -15,6 +16,14 @@ public class GameModel {
 
     @Id // Marks the primary key for this document's ID
     private String id;
+
+    /**
+     * Guards the read-modify-write race: two moves load the same game, both apply to
+     * their own copy, and whichever saves second silently discards the first. Writing
+     * one document is atomic on its own, so this is all that is left to protect.
+     */
+    @Version
+    private Long version;
 
     private GameState gameState;
 
@@ -158,6 +167,14 @@ public class GameModel {
 
     public void setPlayerIds(List<String> playerIds) {
         this.playerIds = playerIds;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
     }
 
     public Map<String, List<Card>> getHands() {

--- a/backend/src/main/java/com/cardgame/service/GameService.java
+++ b/backend/src/main/java/com/cardgame/service/GameService.java
@@ -327,7 +327,8 @@ public class GameService {
         }
 
         // Check if game is over (for regular moves)
-        if (isGameOver(gameModel)) {
+        boolean completedByThisMove = isGameOver(gameModel);
+        if (completedByThisMove) {
             finalizeGame(gameModel);
         } else {
             handleTurnSwitching(gameModel);
@@ -337,7 +338,11 @@ public class GameService {
         gameModel.setUpdatedAt(Instant.now());
 
         // Save and return updated game state
-        return gameRepository.save(gameModel);
+        GameModel saved = gameRepository.save(gameModel);
+        if (completedByThisMove) {
+            recordGameCompleted(saved);
+        }
+        return saved;
     }
 
     private GameModel handleWinRequestResponse(GameModel gameModel, PlayerAction action) {
@@ -372,7 +377,11 @@ public class GameService {
         gameModel.setUpdatedAt(Instant.now());
 
         // Save and return updated game state
-        return gameRepository.save(gameModel);
+        GameModel saved = gameRepository.save(gameModel);
+        if (accepted) {
+            recordGameCompleted(saved);
+        }
+        return saved;
     }
 
     private boolean isGameOver(GameModel gameModel) {
@@ -421,16 +430,14 @@ public class GameService {
     /**
      * Finalizes a game when it's over, calculating scores and determining the winner.
      *
+     * <p>Changes the game and nothing else. Everything with an effect outside this
+     * document waits for {@link #recordGameCompleted}, once the save has gone through.
+     *
      * @param gameModel The game model to finalize
      */
     private void finalizeGame(GameModel gameModel) {
         // Set game state to completed
         gameModel.setGameState(GameState.COMPLETED);
-        
-        // Track metrics
-        gameCompletedCounter.increment();
-        metricsConfig.decrementActiveGames();
-        logger.info("Game completed with ID: {}", gameModel.getId());
 
         Map<Integer, ScoreCalculator.ColumnScore> columnScores = ScoreCalculator.calculateColumnScores(gameModel);
 
@@ -448,10 +455,19 @@ public class GameService {
         String winnerId = ScoreCalculator.determineWinner(gameModel);
         gameModel.setWinnerId(winnerId);
         gameModel.setTie(winnerId == null);
+    }
 
-        // A finished game touches its players once each, for the one thing that genuinely
-        // belongs to them and outlives the game.
-        settleLifetimeScores(gameModel, winnerId);
+    /**
+     * Everything a completed game owes the world outside its own document, run once the
+     * game has been saved. A finished game touches its players once each, for the one
+     * thing that genuinely belongs to them and outlives the game.
+     */
+    private void recordGameCompleted(GameModel gameModel) {
+        gameCompletedCounter.increment();
+        metricsConfig.decrementActiveGames();
+        logger.info("Game completed with ID: {}", gameModel.getId());
+
+        settleLifetimeScores(gameModel, gameModel.getWinnerId());
     }
 
     /**

--- a/backend/src/main/java/com/cardgame/service/GameService.java
+++ b/backend/src/main/java/com/cardgame/service/GameService.java
@@ -1,6 +1,7 @@
 package com.cardgame.service;
 
 import com.cardgame.dto.*;
+import com.cardgame.exception.game.ConcurrentMoveException;
 import com.cardgame.exception.game.GameNotFoundException;
 import com.cardgame.exception.game.InvalidMoveException;
 import com.cardgame.model.Board;
@@ -23,6 +24,7 @@ import io.micrometer.core.instrument.Counter;
 import org.checkerframework.checker.units.qual.C;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -298,6 +300,26 @@ public class GameService {
      * that nothing looked at.
      */
     public GameModel applyMove(String gameId, PlayerAction action) {
+        try {
+            return attemptMove(gameId, action);
+        } catch (OptimisticLockingFailureException firstFailure) {
+            // Somebody else changed the game between the read and the write. The move was
+            // applied to a copy that is now stale, so it was not applied at all — read the
+            // game again and replay it against what is actually there.
+            logger.info("Move on game {} lost the version check, retrying once", gameId);
+        }
+
+        try {
+            return attemptMove(gameId, action);
+        } catch (OptimisticLockingFailureException secondFailure) {
+            // Twice is no longer a coincidence worth retrying through. Say so, rather than
+            // returning a game state that does not contain the move the player made.
+            throw new ConcurrentMoveException(
+                    "The game changed while your move was being applied. Reload the game state.");
+        }
+    }
+
+    private GameModel attemptMove(String gameId, PlayerAction action) {
         GameModel gameModel = gameRepository.findById(gameId)
                 .orElseThrow(() -> new GameNotFoundException("Game not found: " + gameId));
 
@@ -431,7 +453,9 @@ public class GameService {
      * Finalizes a game when it's over, calculating scores and determining the winner.
      *
      * <p>Changes the game and nothing else. Everything with an effect outside this
-     * document waits for {@link #recordGameCompleted}, once the save has gone through.
+     * document — the victory bonus, the leaderboard, the counters — waits for
+     * {@link #recordGameCompleted} once the save has actually gone through, because a
+     * save can fail on the version check and be retried.
      *
      * @param gameModel The game model to finalize
      */
@@ -459,8 +483,11 @@ public class GameService {
 
     /**
      * Everything a completed game owes the world outside its own document, run once the
-     * game has been saved. A finished game touches its players once each, for the one
-     * thing that genuinely belongs to them and outlives the game.
+     * game has been saved.
+     *
+     * <p>Kept apart from {@link #finalizeGame} because a move can be applied, lose the
+     * version check and be applied again. Awarding the victory bonus before the save
+     * would award it twice.
      */
     private void recordGameCompleted(GameModel gameModel) {
         gameCompletedCounter.increment();

--- a/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
+++ b/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
@@ -3,6 +3,7 @@ package com.cardgame.websocket;
 import com.cardgame.dto.ImmutablePlayerAction;
 import com.cardgame.dto.PlayerAction;
 import com.cardgame.dto.PlayerAction.ActionType;
+import com.cardgame.exception.game.ConcurrentMoveException;
 import com.cardgame.model.Card;
 import com.cardgame.model.Position;
 import com.cardgame.service.GameService;
@@ -326,6 +327,12 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
                     updatedGame.getId(), updatedGame.getWinnerId(), updatedGame.getPlayerScores());
             }
             
+        } catch (ConcurrentMoveException e) {
+            // The move was legal and was not applied. Hand back what the game actually
+            // says instead of leaving the client showing a move the server never took.
+            logger.warn("Move on match {} gave up after two version conflicts", info.matchId);
+            sendCurrentState(session, info);
+            sendError(session, e.getMessage());
         } catch (Exception e) {
             logger.error("Failed to process game action", e);
             sendError(session, "Failed to process action: " + e.getMessage());
@@ -371,8 +378,25 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         }
     }
     
+    /**
+     * Sends one session the game as it currently stands. The same message a client gets
+     * when it asks for the state itself, so nothing on the client has to learn a new
+     * shape to recover from a refused move.
+     */
+    private void sendCurrentState(WebSocketSession session, SessionInfo info) {
+        try {
+            var gameModel = nakamaMatchService.getMatchState(info.matchId);
+            sendMessage(session, new WebSocketMessage(
+                MessageType.GAME_STATE_UPDATE,
+                gameService.convertToDto(gameModel, info.playerId)
+            ));
+        } catch (Exception e) {
+            logger.error("Could not send current state for match {}", info.matchId, e);
+        }
+    }
+
     // Utility methods
-    
+
     private void sendMessage(WebSocketSession session, WebSocketMessage message) {
         try {
             String json = objectMapper.writeValueAsString(message);

--- a/backend/src/test/java/com/cardgame/service/ConcurrentMoveTest.java
+++ b/backend/src/test/java/com/cardgame/service/ConcurrentMoveTest.java
@@ -1,0 +1,212 @@
+package com.cardgame.service;
+
+import com.cardgame.dto.CardDto;
+import com.cardgame.dto.GameDto;
+import com.cardgame.dto.ImmutablePlayerAction;
+import com.cardgame.dto.PlayerAction;
+import com.cardgame.exception.game.ConcurrentMoveException;
+import com.cardgame.model.Card;
+import com.cardgame.model.Deck;
+import com.cardgame.model.GameModel;
+import com.cardgame.model.Player;
+import com.cardgame.model.Position;
+import com.cardgame.repository.CardRepository;
+import com.cardgame.repository.DeckRepository;
+import com.cardgame.repository.GameRepository;
+import com.cardgame.repository.PlayerRepository;
+import com.cardgame.support.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * A move reads the game, changes it and writes it back. Two moves that interleave those
+ * three steps would leave whichever wrote second having silently discarded the first.
+ */
+@DisplayName("Optimistic locking on the move path")
+@TestPropertySource(properties = "spring.data.mongodb.database=card_game_test_concurrentmove")
+class ConcurrentMoveTest extends IntegrationTestBase {
+
+    private static final int DECK_SIZE = 5;
+
+    @Autowired
+    private GameService gameService;
+
+    /**
+     * A spy rather than a mock: every test here needs the real repository, and two of
+     * them need one save to fail at a moment no amount of setup from outside can reach.
+     */
+    @MockitoSpyBean
+    private GameRepository gameRepository;
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Autowired
+    private DeckRepository deckRepository;
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    private Player player1;
+    private Player player2;
+    private Deck deck1;
+    private Deck deck2;
+
+    @BeforeEach
+    void setUp() {
+        gameRepository.deleteAll();
+        playerRepository.deleteAll();
+        deckRepository.deleteAll();
+        cardRepository.deleteAll();
+
+        List<Card> cards1 = createCards("p1");
+        List<Card> cards2 = createCards("p2");
+
+        player1 = newPlayer("ConcurrentPlayer1");
+        player2 = newPlayer("ConcurrentPlayer2");
+
+        deck1 = newDeck(player1.getId(), cards1);
+        deck2 = newDeck(player2.getId(), cards2);
+    }
+
+    private Player newPlayer(String name) {
+        Player player = new Player();
+        player.setId(UUID.randomUUID().toString());
+        player.setName(name);
+        return playerRepository.save(player);
+    }
+
+    private Deck newDeck(String ownerId, List<Card> cards) {
+        Deck deck = new Deck();
+        deck.setId(UUID.randomUUID().toString());
+        deck.setOwnerId(ownerId);
+        deck.setCards(cards);
+        deck.setRemainingCards(DECK_SIZE);
+        return deckRepository.save(deck);
+    }
+
+    private List<Card> createCards(String prefix) {
+        List<Card> cards = new ArrayList<>();
+        for (int i = 1; i <= DECK_SIZE; i++) {
+            Card card = new Card(prefix + "_card_" + i, i, "Card " + i);
+            cards.add(card);
+            cardRepository.save(card);
+        }
+        return cards;
+    }
+
+    @Test
+    @DisplayName("a game is created with a version")
+    void newGameIsVersioned() {
+        GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+
+        GameModel stored = gameRepository.findById(game.getId()).orElseThrow();
+        assertNotNull(stored.getVersion(), "a saved game should carry a version");
+    }
+
+    @Test
+    @DisplayName("a move increments the version")
+    void moveIncrementsVersion() {
+        GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        long before = gameRepository.findById(game.getId()).orElseThrow().getVersion();
+
+        gameService.applyMove(game.getId(), placeFirstCardAt(game, new Position(1, 4)));
+
+        long after = gameRepository.findById(game.getId()).orElseThrow().getVersion();
+        assertEquals(before + 1, after);
+    }
+
+    @Test
+    @DisplayName("a stale copy of a game cannot be saved over a newer one")
+    void staleWriteIsRefused() {
+        GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+
+        // Two readers, as two concurrent moves would be.
+        GameModel first = gameRepository.findById(game.getId()).orElseThrow();
+        GameModel second = gameRepository.findById(game.getId()).orElseThrow();
+
+        first.setUpdatedAt(java.time.Instant.now());
+        gameRepository.save(first);
+
+        // The second still believes in the version it read, which is no longer the one on
+        // the document. Without @Version this save would land and the first would vanish.
+        second.setUpdatedAt(java.time.Instant.now());
+        assertThrows(OptimisticLockingFailureException.class, () -> gameRepository.save(second));
+    }
+
+    @Test
+    @DisplayName("a move that loses the race once is retried, not lost")
+    void moveIsRetriedAfterOneConflict() {
+        GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        PlayerAction action = placeFirstCardAt(game, new Position(1, 4));
+
+        // Lose the first save the way a concurrent writer would, then let the second
+        // through. Stubbing the save is the only way to land inside the window between
+        // the read and the write, which is the whole of what @Version protects; the reset
+        // is how the stub steps aside afterwards, since a repository is an interface and
+        // there is no real method for Mockito to fall through to.
+        AtomicInteger interceptedSaves = new AtomicInteger();
+        doAnswer(invocation -> {
+            interceptedSaves.incrementAndGet();
+            reset(gameRepository);
+            throw new OptimisticLockingFailureException("beaten to the save");
+        }).when(gameRepository).save(any(GameModel.class));
+
+        GameModel result = gameService.applyMove(game.getId(), action);
+
+        assertEquals(1, interceptedSaves.get(), "exactly one save should have been made to fail");
+        assertTrue(result.getBoard().getPieces().containsKey("1,4"), "the move should have been applied");
+        assertEquals(player2.getId(), result.getCurrentPlayerId(), "and the turn should have passed");
+    }
+
+    @Test
+    @DisplayName("a move that keeps losing the race is refused, not silently dropped")
+    void repeatedConflictIsReported() {
+        GameDto game = gameService.initializeGame(player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        PlayerAction action = placeFirstCardAt(game, new Position(1, 4));
+
+        AtomicInteger attemptedSaves = new AtomicInteger();
+        doAnswer(invocation -> {
+            attemptedSaves.incrementAndGet();
+            throw new OptimisticLockingFailureException("beaten to the save");
+        }).when(gameRepository).save(any(GameModel.class));
+
+        ConcurrentMoveException thrown = assertThrows(ConcurrentMoveException.class,
+                () -> gameService.applyMove(game.getId(), action));
+        assertTrue(thrown.getMessage().toLowerCase().contains("reload"),
+                "the client should be told to resync, but got: " + thrown.getMessage());
+
+        // Two attempts and no more: retrying for ever would hold a request open.
+        assertEquals(2, attemptedSaves.get());
+
+        // And the move really was not applied.
+        reset(gameRepository);
+        GameModel stored = gameRepository.findById(game.getId()).orElseThrow();
+        assertFalse(stored.getBoard().getPieces().containsKey("1,4"));
+    }
+
+    private PlayerAction placeFirstCardAt(GameDto game, Position position) {
+        CardDto cardDto = game.getCurrentPlayerHand().get(0);
+        return ImmutablePlayerAction.builder()
+                .type(PlayerAction.ActionType.PLACE_CARD)
+                .playerId(game.getCurrentPlayerId())
+                .card(new Card(cardDto.getId(), cardDto.getPower(), cardDto.getName()))
+                .targetPosition(position)
+                .timestamp(System.currentTimeMillis())
+                .build();
+    }
+}

--- a/infra/migrations/2026-08-17-game-version.js
+++ b/infra/migrations/2026-08-17-game-version.js
@@ -1,0 +1,19 @@
+// Give every existing game a version, before deploying optimistic locking.
+//
+//   mongosh "$MONGODB_URI" --file infra/migrations/2026-08-17-game-version.js
+//
+// Run this BEFORE the deploy, unlike the migration next to it. Spring Data reads a
+// missing @Version field as null, treats the entity as new, and issues an insert — which
+// hits the existing _id and fails with a duplicate key error rather than an optimistic
+// locking one. A game written before this field existed would therefore refuse every
+// move made in it, and refuse it in a way the retry does not catch. Measured, not
+// assumed: the probe threw E11000 on the first save.
+//
+// Idempotent: running it twice does nothing the second time.
+
+const result = db.games.updateMany(
+  { version: { $exists: false } },
+  { $set: { version: NumberLong("0") } }
+);
+
+printjson({ gamesVersioned: result.modifiedCount });


### PR DESCRIPTION
Phase 2 of the notes. Small, because phase 1 did the work: a move is one document write and MongoDB is atomic per document, so the only thing left is the read-modify-write race — two moves load the same game, both apply, whichever saves second discards the first.

- `@Version` on `GameModel`
- A move that loses the version check is retried once; a second failure sends the client the game as it actually stands and tells it to reload, rather than leaving it showing a move the server never took
- Five tests, including that two attempts is the limit

No transactions. They need a replica set, and Atlas M0 is one — but a single-document write does not need one, which was the point of phase 1.

### Two things that fell out of doing it

**The victory bonus was awarded before the game was saved.** So was the leaderboard submission and the completed-game counter. Harmless while a save could not fail; with a retry in front of it, a move that lost the race once would have awarded the bonus twice. Split into its own step that runs after the write lands.

**A game written before this field existed refuses every move.** Measured with a throwaway probe rather than reasoned about: Spring Data reads a missing `@Version` as null, treats the entity as new and issues an insert, which fails as `DuplicateKeyException` on the existing `_id` — not as a locking failure, so the retry does not catch it either. `infra/migrations/2026-08-17-game-version.js` sets `version: 0` on any game without one.

### Deploying this

The migration runs **before** the deploy this time, which is the opposite of the one in #43 — it is preparing existing documents for code that has not shipped yet, and setting a field the current code ignores.

1. `mongosh "$MONGODB_URI" --file infra/migrations/2026-08-17-game-version.js`
2. Merge, build, push to ECR, deploy the stack.

Production had no games at all as of the last check, so the migration may well report zero. It is worth running anyway — anyone who plays between now and the deploy creates exactly the document it fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)