### PR TITLE
Stop handing out a match code another game already has

### DIFF
--- a/backend/src/main/java/com/cardgame/repository/GameRepository.java
+++ b/backend/src/main/java/com/cardgame/repository/GameRepository.java
@@ -37,6 +37,15 @@ public interface GameRepository extends MongoRepository<GameModel, String> {
     Optional<GameModel> findByNakamaMatchId(String nakamaMatchId);
 
     /**
+     * Whether any game already carries this Nakama match id.
+     *
+     * <p>Used when handing out a match code, so that two games can never share one.
+     * {@link #findByNakamaMatchId} is the reason it matters: it expects a single result
+     * and throws if it finds two, which takes both games with it.
+     */
+    boolean existsByNakamaMatchId(String nakamaMatchId);
+
+    /**
      * Delete every game this player took part in, whatever state it is in.
      *
      * <p>A game names its participants and nothing else names the game, so a game whose

--- a/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
+++ b/backend/src/main/java/com/cardgame/service/nakama/NakamaMatchService.java
@@ -51,6 +51,9 @@ public class NakamaMatchService {
     /** What a game's nakamaMatchId is prefixed with. Written once, read by getMatchState. */
     private static final String NAKAMA_MATCH_ID_PREFIX = "nakama_";
 
+    /** How many codes to draw before giving up on finding an unused one. */
+    private static final int MATCH_ID_ATTEMPTS = 20;
+
     // Store active socket connections
     private final Map<String, SocketClient> activeSockets = new ConcurrentHashMap<>();
     
@@ -491,8 +494,36 @@ public class NakamaMatchService {
     
     // Helper methods
     
+    /**
+     * A match code nobody else is using.
+     *
+     * <p>Six hex characters is 16.7 million codes, which sounds ample and is not: codes
+     * are never reused or retired, so by the birthday bound two games share one after
+     * about 4,800 have ever been created, with even odds. That is not a theoretical
+     * number — a load test making 850 games a run hit it, and when it did, the duplicate
+     * broke <em>both</em> games, because looking a match up expects one result and throws
+     * when it finds two.
+     *
+     * <p>The code stays six characters because a player reads it out to a friend. What
+     * changes is that it is now checked before being handed out, against the matches in
+     * memory and against every game ever saved. With a few thousand games in a space of
+     * 16.7 million, a retry is rare; the loop is bounded so that a genuinely exhausted
+     * space fails loudly rather than spinning.
+     */
     private String generateMatchId() {
-        return UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+        for (int attempt = 0; attempt < MATCH_ID_ATTEMPTS; attempt++) {
+            String candidate = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+            if (matchMetadata.containsKey(candidate)) {
+                continue;
+            }
+            if (gameRepository.existsByNakamaMatchId(NAKAMA_MATCH_ID_PREFIX + candidate)) {
+                logger.info("Match code {} is already taken by a saved game, drawing another", candidate);
+                continue;
+            }
+            return candidate;
+        }
+        throw new IllegalStateException(
+                "Could not find an unused match code in " + MATCH_ID_ATTEMPTS + " attempts");
     }
 
     private String deckIdOf(Player player) {

--- a/backend/src/test/java/com/cardgame/service/nakama/MatchCodeTest.java
+++ b/backend/src/test/java/com/cardgame/service/nakama/MatchCodeTest.java
@@ -1,0 +1,113 @@
+package com.cardgame.service.nakama;
+
+import com.cardgame.model.Board;
+import com.cardgame.model.GameModel;
+import com.cardgame.model.GameState;
+import com.cardgame.repository.GameRepository;
+import com.cardgame.support.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * A match code is six hex characters, which is 16.7 million of them, and they are never
+ * reused. That is fewer than it sounds: by the birthday bound, two games share a code
+ * after about 4,800 have ever been created. A load test making 850 games a run found one.
+ */
+@DisplayName("Match codes")
+@TestPropertySource(properties = "spring.data.mongodb.database=card_game_test_matchcode")
+class MatchCodeTest extends IntegrationTestBase {
+
+    @Autowired
+    private NakamaMatchService nakamaMatchService;
+
+    /** A spy so that "this code is taken" can be arranged without creating 4,800 games. */
+    @MockitoSpyBean
+    private GameRepository gameRepository;
+
+    @BeforeEach
+    void setUp() {
+        gameRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("a duplicate breaks both games, which is why they have to be unique")
+    void duplicateCodeBreaksBothGames() {
+        // Written directly, the way the old generator could have written them.
+        saveGameWithCode("nakama_ABC123");
+        saveGameWithCode("nakama_ABC123");
+
+        // Neither game can be opened again. Not one of them — both.
+        assertThrows(IncorrectResultSizeDataAccessException.class,
+                () -> gameRepository.findByNakamaMatchId("nakama_ABC123"));
+    }
+
+    @Test
+    @DisplayName("a code that a saved game already holds is drawn again")
+    void takenCodeIsDrawnAgain() {
+        // Waiting for a natural collision would mean creating thousands of games, so the
+        // check is made to report "taken" for the first two codes instead. What is being
+        // proved is that the answer is consulted at all and that a taken code is not
+        // handed out, not the odds of drawing one.
+        AtomicInteger checks = new AtomicInteger();
+        doAnswer(invocation -> checks.incrementAndGet() <= 2)
+                .when(gameRepository).existsByNakamaMatchId(anyString());
+
+        String code = nakamaMatchService.createMatch("player-retrying").join();
+
+        assertNotNull(code);
+        assertEquals(3, checks.get(), "two codes should have been rejected and the third taken");
+    }
+
+    @Test
+    @DisplayName("an exhausted space fails loudly rather than spinning")
+    void exhaustedSpaceGivesUp() {
+        doReturn(true).when(gameRepository).existsByNakamaMatchId(anyString());
+
+        CompletionException thrown = assertThrows(CompletionException.class,
+                () -> nakamaMatchService.createMatch("player-with-no-codes-left").join());
+
+        Throwable root = thrown;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertInstanceOf(IllegalStateException.class, root);
+        assertTrue(root.getMessage().contains("unused match code"), root.getMessage());
+    }
+
+    @Test
+    @DisplayName("codes handed out at the same time are all different")
+    void concurrentCodesAreDistinct() {
+        List<String> codes = IntStream.range(0, 60)
+                .parallel()
+                .mapToObj(i -> nakamaMatchService.createMatch("concurrent-player-" + i).join())
+                .toList();
+
+        assertEquals(codes.size(), Set.copyOf(codes).size(), "every code should be distinct");
+    }
+
+    private void saveGameWithCode(String nakamaMatchId) {
+        GameModel game = new GameModel();
+        game.setId(UUID.randomUUID().toString());
+        game.setGameState(GameState.IN_PROGRESS);
+        game.setBoard(new Board());
+        game.setPlayerIds(List.of("a", "b"));
+        game.setNakamaMatchId(nakamaMatchId);
+        gameRepository.save(game);
+    }
+}


### PR DESCRIPTION
Found by the load test, not by reading the code. Pre-existing — nothing to do with the recent work.

A match code is `UUID.randomUUID().toString().substring(0, 6).toUpperCase()`: six hex characters, 16.7 million of them, never reused or retired. By the birthday bound two games share one after about **4,800 games have ever been created**, with even odds. A load test making 850 games a run hit it.

When it happens the duplicate breaks **both** games, not one. `findByNakamaMatchId` expects a single result, so it throws `IncorrectResultSizeDataAccessException` and neither game can be opened again:

```
org.springframework.dao.IncorrectResultSizeDataAccessException:
  Query { "nakamaMatchId" : "nakama_557E8B" } returned non unique result
```

The code stays six characters — a player reads it out to a friend — but it is now checked against the matches in memory and against every game ever saved before being handed out, with a bounded retry so an exhausted space fails loudly rather than spinning.

### Tests

Four, and the two that matter were checked against a build with the retry loop removed and do fail there:

- a duplicate breaks both games — states the defect being fixed
- a code a saved game already holds is drawn again
- an exhausted space gives up rather than spinning
- codes handed out concurrently are all distinct

The first is arranged by writing two games with the same code directly; the middle two arrange "taken" through a spy, because waiting for a natural collision would mean creating thousands of games.

### Not done here

No unique index on `nakamaMatchId`. It would be the stronger guarantee, but it is the same trap `CLAUDE.md` already records for `Player`: a database that already holds duplicates refuses to build the index and the application will not start. Production has no games at all right now, so it could be added cleanly — as its own change, with the audit that implies.

A six-character hex code is also 16.7 million guesses away from someone else's waiting match. Not urgent while there are no waiting matches to find, and a wider alphabet in the same six characters would give 1.07 billion — worth doing when match discovery matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)