### PR TITLE
Call the browser tab Hand of Fate

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-    title: "Queen's Blood",
+    title: 'Hand of Fate',
     description: 'A strategic card placement game',
 }
 


### PR DESCRIPTION
The browser tab still said `Queen's Blood`, the working title the project started from. It was the only place left — the home page, the login page, the tutorials and the game board all say Hand of Fate already, which is why it only showed up in the tab.

One line in `frontend/src/app/layout.tsx`. Frontend only, so it ships with the Vercel deploy on merge; no backend deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)