### PR TITLE
Send moves over the open socket, and draw them at once

### DIFF
--- a/backend/src/main/java/com/cardgame/controller/GameController.java
+++ b/backend/src/main/java/com/cardgame/controller/GameController.java
@@ -111,12 +111,7 @@ public class GameController {
             @RequestBody PlayerMoveRequest moveRequest) {
         gameAccess.requireMayActAs(gameId, moveRequest.getPlayerId());
         PlayerAction action = convertToPlayerAction(moveRequest);
-        GameDto updatedGame = gameService.processMove(gameId, action);
-        
-        // Broadcast the update via WebSocket for online games
-        broadcastGameUpdateIfOnline(gameId, updatedGame);
-        
-        return ResponseEntity.ok(updatedGame);
+        return applyAndBroadcast(gameId, action);
     }
 
     @PostMapping("/{gameId}/pass")
@@ -129,12 +124,7 @@ public class GameController {
                 .playerId(passRequest.getPlayerId())
                 .timestamp(System.currentTimeMillis())
                 .build();
-        GameDto updatedGame = gameService.processMove(gameId, action);
-        
-        // Broadcast the update via WebSocket for online games
-        broadcastGameUpdateIfOnline(gameId, updatedGame);
-        
-        return ResponseEntity.ok(updatedGame);
+        return applyAndBroadcast(gameId, action);
     }
 
     private PlayerAction convertToPlayerAction(PlayerMoveRequest moveRequest) {
@@ -170,12 +160,7 @@ public class GameController {
                 .playerId(request.getPlayerId())
                 .timestamp(System.currentTimeMillis())
                 .build();
-        GameDto updatedGame = gameService.processMove(gameId, action);
-        
-        // Broadcast the update via WebSocket for online games
-        broadcastGameUpdateIfOnline(gameId, updatedGame);
-        
-        return ResponseEntity.ok(updatedGame);
+        return applyAndBroadcast(gameId, action);
     }
 
     /**
@@ -192,40 +177,40 @@ public class GameController {
                 .actionData(request.isAccepted())
                 .timestamp(System.currentTimeMillis())
                 .build();
-        GameDto updatedGame = gameService.processMove(gameId, action);
-        
-        // Broadcast the update via WebSocket for online games
-        broadcastGameUpdateIfOnline(gameId, updatedGame);
-        
-        return ResponseEntity.ok(updatedGame);
+        return applyAndBroadcast(gameId, action);
     }
     
     /**
      * Helper method to broadcast game updates via WebSocket for online games ONLY
      * This method is safe for local mode - it checks if the game is online before broadcasting
      */
-    private void broadcastGameUpdateIfOnline(String gameId, GameDto updatedGame) {
-        try {
-            // Get the game model to check if it's an online game
-            GameModel gameModel = gameService.getGameModel(gameId);
-            
-            // SAFETY CHECK: Only broadcast for online games
-            if (gameModel.getGameMode() == GameMode.ONLINE && gameModel.getNakamaMatchId() != null) {
-                // Extract match ID from Nakama match ID (format: "nakama_XXXXXX")
-                String matchId = gameModel.getNakamaMatchId().replace("nakama_", "");
-                
-                // Broadcast to all players in the match
-                // The WebSocket handler will take care of sending to all connected sessions
-                gameWebSocketHandler.broadcastGameUpdate(matchId, updatedGame);
-                
-                log.info("Broadcasted game update for online match {} after REST API move", matchId);
-            } else {
-                // Local mode game - no broadcast needed
-                log.debug("Game {} is in local mode, skipping WebSocket broadcast", gameId);
+    /**
+     * Applies an action, tells everyone else about it, and answers the caller.
+     *
+     * <p>The answer is built for **whoever made the move**. It used to be built for
+     * whoever's turn it had become, which after a move is the opponent — so a player
+     * posting a move was handed their opponent's hand. Local hot-seat is the one case
+     * where the old behaviour is the right one: the same screen belongs to the next
+     * player as soon as the turn passes.
+     *
+     * <p>The game is read once. Applying it, deciding whether to broadcast and building
+     * the views all work from that one copy; each of those three used to read it again.
+     */
+    private ResponseEntity<GameDto> applyAndBroadcast(String gameId, PlayerAction action) {
+        GameModel updated = gameService.applyMove(gameId, action);
+
+        boolean online = updated.getGameMode() == GameMode.ONLINE && updated.getNakamaMatchId() != null;
+        if (online) {
+            try {
+                String matchId = updated.getNakamaMatchId().replace("nakama_", "");
+                gameWebSocketHandler.broadcastGameUpdate(matchId, updated);
+            } catch (Exception e) {
+                // A failed broadcast must not fail the move, which is already saved.
+                log.error("Failed to broadcast game update for game {}", gameId, e);
             }
-        } catch (Exception e) {
-            log.error("Failed to broadcast game update for game {}", gameId, e);
-            // Don't fail the request if broadcast fails - this ensures local mode continues to work
         }
+
+        String forPlayerId = online ? action.getPlayerId() : updated.getCurrentPlayerId();
+        return ResponseEntity.ok(gameService.convertToDto(updated, forPlayerId));
     }
 }

--- a/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
+++ b/backend/src/main/java/com/cardgame/websocket/GameWebSocketHandler.java
@@ -431,6 +431,31 @@ public class GameWebSocketHandler extends TextWebSocketHandler {
         }
     }
     
+    /**
+     * Sends every session in a match the game as its own player sees it.
+     *
+     * <p>Takes the game rather than a view of it, because a view belongs to one player
+     * and each session needs its own. The overload below re-read the game to get back to
+     * this; callers that already hold it should use this one.
+     */
+    public void broadcastGameUpdate(String matchId, com.cardgame.model.GameModel gameModel) {
+        Set<WebSocketSession> sessions = matchSessions.get(matchId);
+        if (sessions == null || sessions.isEmpty()) {
+            logger.warn("No sessions found for match {} when trying to broadcast", matchId);
+            return;
+        }
+        logger.info("Broadcasting game update to {} players in match {}", sessions.size(), matchId);
+        for (WebSocketSession session : sessions) {
+            SessionInfo sInfo = sessionInfoMap.get(session.getId());
+            if (sInfo != null) {
+                sendMessage(session, new WebSocketMessage(
+                    MessageType.GAME_STATE_UPDATE,
+                    gameService.convertToDto(gameModel, sInfo.playerId)
+                ));
+            }
+        }
+    }
+
     public void broadcastGameUpdate(String matchId, Object gameState) {
         WebSocketMessage message = new WebSocketMessage();
         message.setType(MessageType.GAME_STATE_UPDATE);

--- a/backend/src/test/java/com/cardgame/controller/MoveResponseViewTest.java
+++ b/backend/src/test/java/com/cardgame/controller/MoveResponseViewTest.java
@@ -1,0 +1,232 @@
+package com.cardgame.controller;
+
+import com.cardgame.dto.CardDto;
+import com.cardgame.dto.GameDto;
+import com.cardgame.dto.ImmutablePlayerAction;
+import com.cardgame.dto.PlayerAction;
+import com.cardgame.model.Card;
+import com.cardgame.model.Deck;
+import com.cardgame.model.GameMode;
+import com.cardgame.model.GameModel;
+import com.cardgame.model.Player;
+import com.cardgame.model.Position;
+import com.cardgame.repository.CardRepository;
+import com.cardgame.repository.DeckRepository;
+import com.cardgame.repository.GameRepository;
+import com.cardgame.repository.PlayerRepository;
+import com.cardgame.service.GameService;
+import com.cardgame.support.IntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.cardgame.support.TestJwtSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Who a move's answer is built for.
+ *
+ * <p>`convertToDto` fills `currentPlayerHand` for whoever it is asked about, and a move
+ * ends with the turn having passed — so answering a move with the view of whoever's turn
+ * it now is hands the mover their opponent's cards.
+ */
+@DisplayName("The view a move is answered with")
+@AutoConfigureMockMvc
+@Import(TestJwtSupport.class)
+@TestPropertySource(properties = "spring.data.mongodb.database=card_game_test_moveview")
+class MoveResponseViewTest extends IntegrationTestBase {
+
+    private static final int DECK_SIZE = 5;
+
+    private static final String P1_SUPABASE_ID = "moveview-p1-supabase";
+
+    @Autowired
+    private GameService gameService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Autowired
+    private DeckRepository deckRepository;
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    private Player player1;
+    private Player player2;
+    private Deck deck1;
+    private Deck deck2;
+
+    @BeforeEach
+    void setUp() {
+        gameRepository.deleteAll();
+        playerRepository.deleteAll();
+        deckRepository.deleteAll();
+        cardRepository.deleteAll();
+
+        player1 = newPlayer("MoveViewPlayer1", P1_SUPABASE_ID);
+        player2 = newPlayer("MoveViewPlayer2");
+        deck1 = newDeck(player1.getId(), createCards("p1"));
+        deck2 = newDeck(player2.getId(), createCards("p2"));
+    }
+
+    @Test
+    @DisplayName("is the mover's own, not whoever's turn it now is")
+    void answersTheMoverWithTheirOwnHand() {
+        GameDto created = gameService.initializeGame(
+                player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        markOnline(created.getId());
+
+        PlayerAction action = placeFirstCardAt(created, new Position(1, 4));
+        GameModel updated = gameService.applyMove(created.getId(), action);
+
+        // The turn has passed, so "the current player" is the opponent now.
+        assertEquals(player2.getId(), updated.getCurrentPlayerId());
+
+        GameDto answer = gameService.convertToDto(updated, player1.getId());
+
+        // Player 1 asked; player 1's cards come back.
+        assertEquals(cardIds(updated.handOf(player1.getId())),
+                dtoCardIds(answer.getCurrentPlayerHand()));
+
+        // And none of player 2's, which is what answering with the current player's view
+        // would have sent — the mover would have been handed their opponent's hand.
+        List<String> opponentCards = cardIds(updated.handOf(player2.getId()));
+        for (String id : dtoCardIds(answer.getCurrentPlayerHand())) {
+            assertFalse(opponentCards.contains(id), "opponent card " + id + " leaked into the answer");
+        }
+    }
+
+    @Test
+    @DisplayName("does not depend on whose turn it is")
+    void theOpponentsViewIsTheirOwnToo() {
+        GameDto created = gameService.initializeGame(
+                player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        markOnline(created.getId());
+
+        GameModel updated = gameService.applyMove(
+                created.getId(), placeFirstCardAt(created, new Position(1, 4)));
+
+        GameDto forPlayer2 = gameService.convertToDto(updated, player2.getId());
+        assertEquals(cardIds(updated.handOf(player2.getId())),
+                dtoCardIds(forPlayer2.getCurrentPlayerHand()));
+    }
+
+    @Test
+    @DisplayName("the moves endpoint does not answer with the opponent's hand")
+    void theEndpointDoesNotLeakTheOpponentsHand() throws Exception {
+        GameDto created = gameService.initializeGame(
+                player1.getId(), player2.getId(), deck1.getId(), deck2.getId());
+        markOnline(created.getId());
+
+        CardDto toPlace = created.getCurrentPlayerHand().get(0);
+        String body = objectMapper.writeValueAsString(java.util.Map.of(
+                "playerId", player1.getId(),
+                "card", java.util.Map.of("id", toPlace.getId(), "power", toPlace.getPower(),
+                        "name", toPlace.getName()),
+                "position", java.util.Map.of("x", 1, "y", 4)));
+
+        String response = mockMvc.perform(post("/game/" + created.getId() + "/moves")
+                        .header(HttpHeaders.AUTHORIZATION, TestJwtSupport.bearerFor(P1_SUPABASE_ID))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        GameModel after = gameRepository.findById(created.getId()).orElseThrow();
+        List<String> opponentCards = cardIds(after.handOf(player2.getId()));
+
+        JsonNode hand = objectMapper.readTree(response).get("currentPlayerHand");
+        List<String> answered = new ArrayList<>();
+        hand.forEach(c -> answered.add(c.get("id").asText()));
+
+        assertFalse(answered.isEmpty(), "the mover should get a hand back");
+        for (String id : answered) {
+            assertFalse(opponentCards.contains(id),
+                    "the answer to player 1's move contained player 2's card " + id);
+        }
+        assertEquals(cardIds(after.handOf(player1.getId())), answered,
+                "the answer should be the mover's own hand");
+    }
+
+    private void markOnline(String gameId) {
+        GameModel game = gameRepository.findById(gameId).orElseThrow();
+        game.setGameMode(GameMode.ONLINE);
+        game.setNakamaMatchId("nakama_VIEW01");
+        gameRepository.save(game);
+    }
+
+    private PlayerAction placeFirstCardAt(GameDto game, Position position) {
+        CardDto cardDto = game.getCurrentPlayerHand().get(0);
+        return ImmutablePlayerAction.builder()
+                .type(PlayerAction.ActionType.PLACE_CARD)
+                .playerId(game.getCurrentPlayerId())
+                .card(new Card(cardDto.getId(), cardDto.getPower(), cardDto.getName()))
+                .targetPosition(position)
+                .timestamp(System.currentTimeMillis())
+                .build();
+    }
+
+    private List<String> cardIds(List<Card> cards) {
+        return cards.stream().map(Card::getId).toList();
+    }
+
+    private List<String> dtoCardIds(List<CardDto> cards) {
+        return cards.stream().map(CardDto::getId).toList();
+    }
+
+    private Player newPlayer(String name) {
+        return newPlayer(name, null);
+    }
+
+    private Player newPlayer(String name, String supabaseUserId) {
+        Player player = new Player();
+        player.setId(UUID.randomUUID().toString());
+        player.setName(name);
+        player.setSupabaseUserId(supabaseUserId);
+        return playerRepository.save(player);
+    }
+
+    private Deck newDeck(String ownerId, List<Card> cards) {
+        Deck deck = new Deck();
+        deck.setId(UUID.randomUUID().toString());
+        deck.setOwnerId(ownerId);
+        deck.setCards(cards);
+        deck.setRemainingCards(DECK_SIZE);
+        return deckRepository.save(deck);
+    }
+
+    private List<Card> createCards(String prefix) {
+        List<Card> cards = new ArrayList<>();
+        for (int i = 1; i <= DECK_SIZE; i++) {
+            Card card = new Card(prefix + "_card_" + i, i, "Card " + i);
+            cards.add(card);
+            cardRepository.save(card);
+        }
+        return cards;
+    }
+}

--- a/frontend/src/components/game/OnlineGameBoard.tsx
+++ b/frontend/src/components/game/OnlineGameBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -12,7 +12,6 @@ import { Card, Position, GameState } from '@/types/game';
 import { OnlineMatchInfo } from '@/types/gameMode';
 import { useUnifiedAuth } from '@/hooks/useUnifiedAuth';
 import { useRouter } from 'next/navigation';
-import { gameService } from '@/services/gameService';
 import { WifiOff, Wifi, Users, AlertCircle } from 'lucide-react';
 import { onlineGameService } from '@/services/onlineGameService';
 import { gameWebSocketService } from '@/services/gameWebSocketService';
@@ -53,6 +52,34 @@ export default function OnlineGameBoard({ matchId, onBack }: OnlineGameBoardProp
     // Loading states
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    // A move the player has made that the server has not confirmed yet. The board shows
+    // it immediately — waiting for the round trip is a third of a second of a card not
+    // appearing where it was dropped — so this holds what to put back if the server
+    // refuses it, or never answers.
+    const pendingMove = useRef<{ revertTo: GameState; ownershipBefore: Record<string, string>; timer: number } | null>(null);
+
+    // updateBoardCards is declared further down; the revert path needs it from up here.
+    const updateBoardCardsRef = useRef<((state: GameState) => void) | null>(null);
+
+    const settlePendingMove = useCallback(() => {
+        if (pendingMove.current) {
+            window.clearTimeout(pendingMove.current.timer);
+            pendingMove.current = null;
+        }
+    }, []);
+
+    const revertPendingMove = useCallback((reason: string) => {
+        const pending = pendingMove.current;
+        if (!pending) return;
+        window.clearTimeout(pending.timer);
+        pendingMove.current = null;
+        setGameState(pending.revertTo);
+        setCardOwnership(pending.ownershipBefore);
+        updateBoardCardsRef.current?.(pending.revertTo);
+        setIsMyTurn(pending.revertTo.currentPlayerId === user?.playerId);
+        setError(reason);
+    }, [user?.playerId]);
 
     // Redirect if not authenticated
     useEffect(() => {
@@ -125,6 +152,9 @@ export default function OnlineGameBoard({ matchId, onBack }: OnlineGameBoardProp
                             playerNames: state.playerNames || {}
                         };
                         
+                        // The server's word replaces whatever was drawn optimistically.
+                        settlePendingMove();
+
                         setGameState(mappedState);
                         setIsMyTurn(state.currentPlayerId === user.playerId);
                         updateBoardCards(mappedState);
@@ -194,7 +224,14 @@ export default function OnlineGameBoard({ matchId, onBack }: OnlineGameBoardProp
                         setOpponentConnected(true);
                     },
                     onError: (error) => {
-                        setError(error);
+                        // If a move is waiting on the server, this is the server refusing
+                        // it — take it back off the board rather than leaving the player
+                        // looking at a position that does not exist.
+                        if (pendingMove.current) {
+                            revertPendingMove(error);
+                        } else {
+                            setError(error);
+                        }
                     },
                     onConnectionClosed: () => {
                         setConnectionStatus('disconnected');
@@ -375,6 +412,7 @@ export default function OnlineGameBoard({ matchId, onBack }: OnlineGameBoardProp
         
         setBoardCards(cardMap);
     };
+    updateBoardCardsRef.current = updateBoardCards;
 
     // Calculate valid moves - must be adjacent to current player's own cards
     useEffect(() => {
@@ -438,39 +476,64 @@ export default function OnlineGameBoard({ matchId, onBack }: OnlineGameBoardProp
         setValidMoves(moves);
     }, [selectedCard, gameState, isMyTurn, user, cardOwnership]);
 
-    // Handle card placement
-    const handleCellClick = async (x: number, y: number) => {
+    /**
+     * Places a card: on the board at once, and over the socket that is already open.
+     *
+     * <p>The move used to go out as its own HTTP request and the card did not appear
+     * until the server's broadcast came back — a full round trip of a card not being
+     * where it was dropped. It goes over the existing WebSocket now, and the board is
+     * drawn from the move immediately; the server's broadcast replaces it a moment later
+     * and is the authority. If the server refuses, or says nothing at all, the position
+     * is put back.
+     */
+    const handleCellClick = (x: number, y: number) => {
         if (!selectedCard || !isMyTurn || !gameState || !matchInfo) return;
-        
+        if (pendingMove.current) return; // one move at a time until the server answers
+
         const isValid = validMoves.some(move => move.x === x && move.y === y);
         if (!isValid) return;
 
-        try {
-            // Send move through REST API (WebSocket will broadcast the update)
-            const response = await gameService.makeMove(gameState.id, {
-                type: 'PLACE_CARD' as const,
-                playerId: user!.playerId,
-                card: selectedCard,
-                targetPosition: { x, y },
-                timestamp: Date.now()
-            });
-            
-            // Clear selection
-            setSelectedCard(null);
-            setValidMoves([]);
-            
-            // Don't update game state from REST response - wait for WebSocket update
-            // The WebSocket will broadcast the proper player-specific view with column scores
-            if (DEBUG) console.log('Move successful, waiting for WebSocket update');
-            
-            // Only update turn status immediately for better UX
-            if (response) {
-                setIsMyTurn(response.currentPlayerId === user!.playerId);
-            }
-        } catch (err) {
-            setError('Failed to make move');
-            console.error(err);
-        }
+        const card = selectedCard;
+        const positionKey = `${x},${y}`;
+        const revertTo = gameState;
+        const ownershipBefore = cardOwnership;
+
+        const optimistic: GameState = {
+            ...gameState,
+            board: { ...gameState.board, pieces: { ...gameState.board.pieces, [positionKey]: card.id } },
+            placedCards: { ...gameState.placedCards, [card.id]: card },
+            cardOwnership: { ...gameState.cardOwnership, [positionKey]: user!.playerId },
+            currentPlayerHand: gameState.currentPlayerHand.filter(c => c.id !== card.id),
+        };
+
+        setGameState(optimistic);
+        setCardOwnership({ ...ownershipBefore, [positionKey]: user!.playerId });
+        updateBoardCards(optimistic);
+        setSelectedCard(null);
+        setValidMoves([]);
+        // The turn is left alone on purpose: whether it passes depends on whether the
+        // opponent has a legal move, which is the server's to decide. Input is held by
+        // pendingMove until it says.
+        setError(null);
+
+        pendingMove.current = {
+            revertTo,
+            ownershipBefore,
+            // A socket that has gone quiet must not leave a card sitting on the board for
+            // ever. Reconnection does not work yet, so this is the only thing that notices.
+            timer: window.setTimeout(
+                () => revertPendingMove('The server did not confirm your move. Please try again.'),
+                5000,
+            ),
+        };
+
+        gameWebSocketService.sendGameAction({
+            type: 'PLACE_CARD',
+            playerId: user!.playerId,
+            card,
+            targetPosition: { x, y },
+            timestamp: Date.now(),
+        });
     };
 
     // Handle pass action


### PR DESCRIPTION
Three changes from asking where a player's latency actually goes. The measurement first, because it decides which of these is worth anything.

### Where the time goes

Measured from this machine against production, and from the production instance outward:

| | |
|---|---|
| browser → Cloudflare edge (SEA) | 8.1 ms |
| origin ↔ Cloudflare edge (sea10 / pdx03) | 7–8 ms |
| server-side move-to-broadcast, p50 | ~4 ms |
| minimal request through the tunnel, end to end | 30.4 ms |

The tunnel is not misconfigured: `cloudflared` speaks QUIC and registers with `sea10`, `pdx02`, `pdx03` — the nearest colos to us-west-2, and the same colo serving the browser. There is nothing to win there.

Server-side is ~4 ms of a ~34 ms round trip. So the latency a player *feels* is not going to be fixed on the server, which is what makes the client-side change here the one that matters.

### 1. The card appears when you drop it

The board waited for the server's broadcast before drawing anything — the comment said so outright: `// Don't update game state from REST response - wait for WebSocket update`. That is a full round trip of a card not being where the player put it.

It is drawn immediately now. The server's broadcast still arrives and still wins; if the server refuses the move, or says nothing within five seconds, the position is put back. The timeout matters because reconnect is still dead code, so nothing else would notice a socket that had gone quiet.

The turn is deliberately **not** guessed. Whether it passes depends on the opponent having a legal move, which only the server knows, so input is held until it answers rather than flipping the indicator and flipping it back.

### 2. Moves go over the socket that is already open

`gameService.makeMove` posted each move as its own HTTP request while a WebSocket sat open alongside it, and `sendGameAction` — which exists — had **zero callers**. Moves use it now. Pass and the win-request pair still use REST; they are not on the hot path and the WebSocket handler does not accept them.

### 3. A move answered the mover with their opponent's hand

Found while reading the REST path, and it is the reason this PR has a test named after it.

`GameController` built its answer with `processMove`, which builds a view for `gameModel.getCurrentPlayerId()` — and a move ends with the turn having passed. So posting a move returned the **opponent's** hand. Nobody noticed because the client deliberately ignored the response body.

```
the answer to player 1's move contained player 2's card p2_card_1 ==> expected: <false> but was: <true>
```

The answer is built for whoever moved now. Local hot-seat keeps the old behaviour, where the same screen really does belong to the next player once the turn passes.

The same path also read the game three times — applying the move, deciding whether to broadcast, and building the views each did their own read. It reads once.

### Checked

- 148 backend tests, including the endpoint test above, which fails against the previous code
- `tsc --noEmit`, `next lint`, `npm run build`
- 1,775 moves over the WebSocket path against the rebuilt backend, 0 errors

**Not checked in a browser.** The load-test driver speaks the protocol directly, so the React change is typechecked, linted and built but has not been played by hand. Two accounts and one match would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)