### PR TITLE
Keep the hand's copy of a played card, not the client's

### DIFF
--- a/backend/src/main/java/com/cardgame/model/GameModel.java
+++ b/backend/src/main/java/com/cardgame/model/GameModel.java
@@ -242,6 +242,19 @@ public class GameModel {
      * occupied or off the edge; whether the player is allowed to place <em>there</em> is
      * the validator's business, and has already been settled by the time this runs.
      */
+    /**
+     * Moves a card from a player's hand onto the board.
+     *
+     * <p>The card kept is the one out of the hand, not the one passed in. They are
+     * equal — {@link Card#equals} compares id, power and name — but they are not
+     * identical: a move arriving over the WebSocket is rebuilt from JSON field by
+     * field and never carries {@code imageUrl}, so the copy that used to be stored
+     * was a card with no artwork. Every card either player played came out of the
+     * database without a picture while the two dealt at setup kept theirs.
+     *
+     * <p>Taking the hand's copy also means nothing a client sends about a card
+     * survives beyond the equality check the validator already makes.
+     */
     public void playCard(String playerId, Position position, Card card) {
         if (hands == null) {
             hands = new HashMap<>();
@@ -249,10 +262,14 @@ public class GameModel {
         if (placedCards == null) {
             placedCards = new HashMap<>();
         }
-        board.placeCard(position, card.getId());
-        hands.computeIfAbsent(playerId, id -> new ArrayList<>()).remove(card);
+
+        List<Card> hand = hands.computeIfAbsent(playerId, id -> new ArrayList<>());
+        int held = hand.indexOf(card);
+        Card played = held >= 0 ? hand.remove(held) : card;
+
+        board.placeCard(position, played.getId());
         placedCards.computeIfAbsent(playerId, id -> new HashMap<>())
-                .put(position.toStorageString(), card);
+                .put(position.toStorageString(), played);
     }
 
     public String getWinnerId() {

--- a/backend/src/test/java/com/cardgame/model/GameModelPlayCardTest.java
+++ b/backend/src/test/java/com/cardgame/model/GameModelPlayCardTest.java
@@ -1,0 +1,72 @@
+package com.cardgame.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Playing a card, without a Spring context or a database.
+ *
+ * <p>The case that matters is the one that shipped broken: a move arriving over the
+ * WebSocket is rebuilt from JSON field by field and never carries {@code imageUrl},
+ * and {@link Card#equals} compares only id, power and name — so the impostor matched
+ * the card in hand, passed validation, and was stored on the board in its place. Every
+ * card either player played came back from the database without a picture.
+ */
+class GameModelPlayCardTest {
+
+    private static final String PLAYER = "player-1";
+
+    private GameModel gameWithHand(Card... hand) {
+        GameModel game = new GameModel();
+        game.setBoard(new Board());
+        game.seatPlayer(PLAYER, "Ransirat", List.of(hand));
+        return game;
+    }
+
+    @Test
+    void keepsTheHandsCopyOfTheCard_notTheOnePassedIn() {
+        Card dealt = new Card("lightning-1", 3, "Lightning", "/gifs/lightning.png");
+        GameModel game = gameWithHand(dealt);
+
+        // What the WebSocket handler builds out of the action payload: equal to the
+        // dealt card as far as equals() is concerned, but with no artwork.
+        Card fromTheWire = new Card("lightning-1", 3, "Lightning");
+        assertThat(fromTheWire).isEqualTo(dealt);
+
+        game.playCard(PLAYER, new Position(1, 1), fromTheWire);
+
+        Card onBoard = game.placedCardsOf(PLAYER).get("1,1");
+        assertThat(onBoard.getImageUrl())
+                .as("the card on the board keeps the art it was dealt with")
+                .isEqualTo("/gifs/lightning.png");
+    }
+
+    @Test
+    void removesExactlyOneCopyOfADuplicatedCard() {
+        // A deck holds two Sparks. Playing one must not empty the pair.
+        Card first = new Card("spark-a", 1, "Spark", "/gifs/spark.png");
+        Card second = new Card("spark-b", 1, "Spark", "/gifs/spark.png");
+        GameModel game = gameWithHand(first, second);
+
+        game.playCard(PLAYER, new Position(0, 0), new Card("spark-a", 1, "Spark"));
+
+        assertThat(game.handOf(PLAYER)).containsExactly(second);
+        assertThat(game.getBoard().getCardIdAt(new Position(0, 0))).isEqualTo("spark-a");
+    }
+
+    @Test
+    void storesACardTheHandDoesNotHold() {
+        // Validation refuses this before it ever gets here; the model still has to be
+        // predictable if it is called directly, as the opening deal does.
+        GameModel game = gameWithHand();
+        Card stray = new Card("thunder-1", 5, "Thunder", "/gifs/thunder.png");
+
+        game.playCard(PLAYER, new Position(2, 4), stray);
+
+        assertThat(game.placedCardsOf(PLAYER).get("2,4")).isEqualTo(stray);
+        assertThat(game.handOf(PLAYER)).isEmpty();
+    }
+}


### PR DESCRIPTION
Found while playing a real duel against another account: every card either player
played landed on the board with no illustration, just the power sigil, while the
two cards the server deals at setup kept theirs.

`GameWebSocketHandler` rebuilds the `Card` from the action payload field by field
and never copies `imageUrl`. `Card.equals` compares id, power and name only — so
the rebuilt card matched the one in hand, passed `validateMove`, and was written
to `placedCards` in place of the real one. The art was gone from the stored game,
not just from the screen.

`GameModel.playCard` now removes the matching card from the hand and stores that
copy. Doing it there rather than in the handler:

- covers every entry point — the socket, the REST move, and the opening deal;
- means nothing a client sends about a card survives past the equality check the
  validator already makes.

Three plain unit tests, no Spring context and no MongoDB: the art survives a move
arriving without it, playing one of two identical Sparks removes exactly one, and
a card the hand does not hold still behaves predictably (which is how the opening
deal calls it).

The frontend already repairs the display by card name — merged in #50 — so the
board looks right today. This is what makes the stored data right.

**Not deployed by merging.** `deploy-backend.yml` is `workflow_dispatch` only, and
deploying takes the site down for a container start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJqWb6y8cCiQkniYhnRqem